### PR TITLE
Add/Update Suite of Plotting Scripts

### DIFF
--- a/Analyzer/test/finalEEplots.py
+++ b/Analyzer/test/finalEEplots.py
@@ -39,11 +39,11 @@ OPTIONSMAP = {"h_jet_pt"       : {"X" : {"rebin" : 12, "min" : 0, "max" : 1000, 
               "h_jmt_ev0_top6" : {"X" : {"min" : 0.0, "max" : 1.0, "rebin" : 20, "title" : "Jet Momentum Tensor Eigenvalue 0"}},
               "h_jmt_ev1_top6" : {"X" : {"min" : 0.0, "max" : 1.0, "rebin" : 20, "title" : "Jet Momentum Tensor Eigenvalue 1"}},
               "h_jmt_ev2_top6" : {"X" : {"min" : 0.0, "max" : 1.0, "rebin" : 20, "title" : "Jet Momentum Tensor Eigenvalue 2"}},
-              "h_beta_z"       : {"X" : {"rebin" : 20, "title" : "#beta_{z}"}},
+              "h_beta_z"       : {"X" : {"rebin" : 36, "title" : "#beta_{z}"}},
               "h_beta_z_pt20"  : {"X" : {"rebin" : 20, "title" : "#beta_{z}"}},
               "h_beta_z_nvtx"       : {"X" : {"rebin" : 20, "title" : "#beta_{z}"}, "Y" : {"title" : "Number of Vertices"}},
               "h_beta_z_pt20_nvtx"  : {"X" : {"rebin" : 20, "title" : "#beta_{z}"}, "Y" : {"title" : "Number of Vertices"}},
-              "h_deepESM"  : {"X" : {"rebin" : 20, "title" : "DeepESM"}},
+              "h_deepESM"  : {"X" : {"rebin" : 36, "title" : "DeepESM"}},
 }
 
 def doOptions(histo, histoName):
@@ -186,7 +186,7 @@ if __name__ == '__main__':
                 PadFactor = (YMax-YMin) / (RatioYMax-RatioYMin)
 
                 c1 = ROOT.TCanvas("%s"%(name), "%s"%(name), XCANVAS, YCANVAS); 
-                c1.Divide(1,2); c1.cd(1); ROOT.gPad.SetLogy(); ROOT.gPad.SetLogz(); ROOT.gPad.SetPad(XMin, YMin, XMax, YMax)
+                c1.Divide(1,2); c1.cd(1); ROOT.gPad.SetLogz(); ROOT.gPad.SetPad(XMin, YMin, XMax, YMax)
 
                 ROOT.gPad.SetGridy(); ROOT.gPad.SetGridx()
                 ROOT.gPad.SetTopMargin(0.03)

--- a/Analyzer/test/finalHEMstudy.py
+++ b/Analyzer/test/finalHEMstudy.py
@@ -1,0 +1,154 @@
+import sys, os, ROOT, argparse
+
+ROOT.TH1.SetDefaultSumw2()
+ROOT.TH2.SetDefaultSumw2()
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat("")
+ROOT.gStyle.SetPaintTextFormat("3.3f")
+ROOT.gStyle.SetFrameLineWidth(2)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--noVeto", dest="noVeto", help="Path to no veto input dir", default="NULL", type=str) 
+parser.add_argument("--partialVeto", dest="partialVeto", help="Path to partialVeto input dir", default="NULL", type=str) 
+parser.add_argument("--fullVeto", dest="fullVeto", help="Path to fullVeto input dir", default="NULL", type=str) 
+arg = parser.parse_args()
+
+OPTIONSMAP = {"Passbaseline"           : {"X" : {"title" : "N_{J}"}, "Y" : {"title" : "MVA bin"}, "Z" : {"min" : 0.001, "max" : 4e5}},
+              "Passbaseline_Ratio"     : {"X" : {"title" : "N_{J}"}, "Y" : {"title" : "MVA bin"}, "Z" : {"min" : 0.0,   "max" : 0.75}},
+              "Passbaseline_Raw"       : {"X" : {"title" : "N_{J}"}, "Y" : {"title" : "MVA bin"}, "Z" : {"min" : 0.001, "max" : 4e5}},
+              "Passbaseline_Raw_Ratio" : {"X" : {"title" : "N_{J}"}, "Y" : {"title" : "MVA bin"}, "Z" : {"min" : 0.0,   "max" : 0.75}}}
+
+def doOptions(histo, histoName):
+
+    is1D = "TH1" in histo.ClassName()
+
+    for axis, options in OPTIONSMAP[histoName].iteritems():
+
+        if axis == "X":
+            histo.GetXaxis().SetNdivisions(10)
+            histo.GetXaxis().SetTickLength(0)
+            if "rebin" in options:
+                if is1D: histo.Rebin(options["rebin"])
+                else: histo.RebinX(options["rebin"])
+            if "min" in options and "max" in options: histo.GetXaxis().SetRangeUser(options["min"],options["max"])
+            if "title" in options: histo.GetXaxis().SetTitle(options["title"])
+        if axis == "Y":
+            histo.GetYaxis().SetNdivisions(4)
+            histo.GetYaxis().SetTickLength(0)
+            if "rebin" in options:
+                if is1D: histo.Rebin(options["rebin"])
+                else: histo.RebinY(options["rebin"])
+            if "min" in options and "max" in options: histo.SetMinimum(options["min"]); histo.SetMaximum(options["max"])
+            if "title" in options: histo.GetYaxis().SetTitle(options["title"])
+        if axis == "Z":
+            if "min" in options and "max" in options: histo.SetMinimum(options["min"]); histo.SetMaximum(options["max"])
+
+def prettyHisto(histo,magicFactor=1.0,magicFactor2=1.0):
+    histo.GetYaxis().SetLabelSize(0.055); histo.GetYaxis().SetTitleSize(0.06); histo.GetYaxis().SetTitleOffset(0.5)
+    histo.GetXaxis().SetLabelSize(0.055); histo.GetXaxis().SetTitleSize(0.06); histo.GetXaxis().SetTitleOffset(1.0)
+    histo.GetZaxis().SetLabelSize(0.055); histo.GetZaxis().SetTitleSize(0.06)
+
+def fillMap(inRootFile, tag):
+
+    if ".root" not in inRootFile: return
+    histoFile = ROOT.TFile.Open(inRootFile, "READ")
+    for hkey in histoFile.GetListOfKeys():
+
+        name = hkey.GetName()
+        spec = name.split("_")[-1].split(".")[0]
+        
+        if "TH" not in hkey.GetClassName(): continue
+        if "Passbaseline" not in name: continue
+
+        histo = hkey.ReadObj()
+        histo.SetDirectory(0)
+        ROOT.SetOwnership(histo, False)
+
+        histo.Sumw2()
+        
+        if name in MAPPFAHISTOS[tag].keys(): MAPPFAHISTOS[tag][name].Add(histo)
+        else: MAPPFAHISTOS[tag][name] = histo
+
+if __name__ == '__main__':
+
+    XCANVAS = 2400; YCANVAS = 1400
+
+    noVeto = arg.noVeto; partialVeto = arg.partialVeto; fullVeto = arg.fullVeto
+
+    if arg.noVeto == "NULL" or arg.partialVeto == "NULL" or arg.fullVeto == "NULL": quit()
+
+    stub = noVeto.split("_")[-1].split(".")[0]
+
+    outpath = "./plots/HEMVetoStudy/"
+    if not os.path.exists(outpath): os.makedirs(outpath)
+
+    MAPPFAHISTOS = {"noVeto" : {}, "partialVeto" : {}, "fullVeto" : {}}
+
+    fillMap(arg.noVeto,      "noVeto")
+    fillMap(arg.partialVeto, "partialVeto")
+    fillMap(arg.fullVeto,    "fullVeto")
+
+    names = ["Passbaseline", "Passbaseline_Raw"]
+
+    # Save the final histograms
+    for name in names:
+        magicMargins = {"T" : 0.03, "L" : 0.07, "B" : 0.13, "R" : 0.12}
+
+        c1 = ROOT.TCanvas("%s_noVeto"%(name), "%s_noVeto"%(name), XCANVAS, YCANVAS); 
+        ROOT.gPad.SetLogz()
+
+        ROOT.gPad.SetTopMargin(magicMargins["T"])
+        ROOT.gPad.SetLeftMargin(magicMargins["L"])
+        ROOT.gPad.SetBottomMargin(magicMargins["B"])
+        ROOT.gPad.SetRightMargin(magicMargins["R"])
+
+        c2 = ROOT.TCanvas("%s_partialVeto"%(name), "%s_partialVeto"%(name), XCANVAS, YCANVAS); 
+        ROOT.gPad.SetLogz()
+
+        ROOT.gPad.SetTopMargin(magicMargins["T"])
+        ROOT.gPad.SetLeftMargin(magicMargins["L"])
+        ROOT.gPad.SetBottomMargin(magicMargins["B"])
+        ROOT.gPad.SetRightMargin(magicMargins["R"])
+
+        c3 = ROOT.TCanvas("%s_fullVeto"%(name), "%s_fullVeto"%(name), XCANVAS, YCANVAS); 
+        ROOT.gPad.SetLogz()
+
+        ROOT.gPad.SetTopMargin(magicMargins["T"])
+        ROOT.gPad.SetLeftMargin(magicMargins["L"])
+        ROOT.gPad.SetBottomMargin(magicMargins["B"])
+        ROOT.gPad.SetRightMargin(magicMargins["R"])
+
+        c4 = ROOT.TCanvas("%s_fullVetoRatio"%(name), "%s_fullVetoRatio"%(name), XCANVAS, YCANVAS); 
+
+        ROOT.gPad.SetTopMargin(magicMargins["T"])
+        ROOT.gPad.SetLeftMargin(magicMargins["L"])
+        ROOT.gPad.SetBottomMargin(magicMargins["B"])
+        ROOT.gPad.SetRightMargin(magicMargins["R"])
+
+        c5 = ROOT.TCanvas("%s_partialVetoRatio"%(name), "%s_partialVetoRatio"%(name), XCANVAS, YCANVAS); 
+
+        ROOT.gPad.SetTopMargin(magicMargins["T"])
+        ROOT.gPad.SetLeftMargin(magicMargins["L"])
+        ROOT.gPad.SetBottomMargin(magicMargins["B"])
+        ROOT.gPad.SetRightMargin(magicMargins["R"])
+
+        noVeto = MAPPFAHISTOS["noVeto"][name]; partialVeto = MAPPFAHISTOS["partialVeto"][name]; fullVeto = MAPPFAHISTOS["fullVeto"][name]
+        fullVetoRatio    = noVeto.Clone("fullVetoRatio");    fullVetoRatio.Add(fullVeto, -1.0);       fullVetoRatio.Divide(noVeto)
+        partialVetoRatio = noVeto.Clone("partialVetoRatio"); partialVetoRatio.Add(partialVeto, -1.0); partialVetoRatio.Divide(noVeto)
+        noVeto.SetContour(255); partialVeto.SetContour(255); fullVeto.SetContour(255); fullVetoRatio.SetContour(255); partialVetoRatio.SetContour(255)
+
+        prettyHisto(noVeto); prettyHisto(partialVeto); prettyHisto(fullVeto)
+        prettyHisto(fullVetoRatio); prettyHisto(partialVetoRatio)
+
+        theName      = noVeto.GetName()
+        theNameRatio = theName + "_Ratio"
+
+        if theName in OPTIONSMAP: doOptions(noVeto, theName); doOptions(partialVeto, theName); doOptions(fullVeto, theName); doOptions(fullVetoRatio, theNameRatio); doOptions(partialVetoRatio, theNameRatio)
+
+        noVeto.SetTitle(""); partialVeto.SetTitle(""); fullVeto.SetTitle(""); fullVetoRatio.SetTitle(""); partialVetoRatio.SetTitle("")
+
+        c1.cd(); noVeto.Draw("COLZ TEXT E");           c1.SaveAs("%s/%s_%s_noVeto.pdf"%(outpath,stub,name))
+        c2.cd(); partialVeto.Draw("COLZ TEXT E");      c2.SaveAs("%s/%s_%s_partialVeto.pdf"%(outpath,stub,name))
+        c3.cd(); fullVeto.Draw("COLZ TEXT E");         c3.SaveAs("%s/%s_%s_fullVeto.pdf"%(outpath,stub,name))
+        c4.cd(); fullVetoRatio.Draw("COLZ TEXT E");    c4.SaveAs("%s/%s_%s_fullVetoRatio.pdf"%(outpath,stub,name))
+        c5.cd(); partialVetoRatio.Draw("COLZ TEXT E"); c5.SaveAs("%s/%s_%s_partialVetoRatio.pdf"%(outpath,stub,name))

--- a/Analyzer/test/finalNJetsPlots.py
+++ b/Analyzer/test/finalNJetsPlots.py
@@ -1,0 +1,177 @@
+import sys, os, ROOT, argparse
+from collections import defaultdict
+
+ROOT.TH1.SetDefaultSumw2()
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat("")
+ROOT.gStyle.SetPaintTextFormat("3.2f")
+ROOT.gStyle.SetFrameLineWidth(2)
+ROOT.gStyle.SetErrorX(0)
+
+usage = "usage: %prog [options]"
+parser = argparse.ArgumentParser(usage)
+parser.add_argument("--inputDir", dest="inputDir", help="Path to input", default="NULL", type=str) 
+
+arg = parser.parse_args()
+
+OPTIONSMAP = {"h_njets" : {"X" : {"min" : 7, "max" : 15, "title" : "N_{J}"}}}
+
+def makeBandGraph(histoUp, histoDown, color = ROOT.kRed):
+    
+    npoints = histoUp.GetNbinsX() / 2
+
+    graphUp = ROOT.TGraph(npoints)
+    graphDown = ROOT.TGraph(npoints)
+    graphBand = ROOT.TGraph(2*npoints)
+
+    offset = 7
+    for iPoint in xrange(0, npoints+1):
+
+        graphUp.SetPoint(iPoint, histoUp.GetBinCenter(iPoint+offset+1), histoUp.GetBinContent(iPoint+offset+1))
+        graphDown.SetPoint(iPoint, histoUp.GetBinCenter(iPoint+offset+1), histoDown.GetBinContent(iPoint+offset+1))
+
+        graphBand.SetPoint(iPoint, histoUp.GetBinCenter(iPoint+offset+1), histoUp.GetBinContent(iPoint+offset+1))
+        graphBand.SetPoint(npoints+iPoint, histoUp.GetBinCenter(npoints-iPoint+offset+2) , histoDown.GetBinContent(npoints-iPoint+offset+2))
+
+    graphUp.SetLineColor(color); graphUp.SetLineWidth(2)
+    graphDown.SetLineColor(color); graphDown.SetLineWidth(2)
+    graphBand.SetFillColorAlpha(color, 0.35)
+
+    return graphUp, graphDown, graphBand
+
+def doOptions(histo, histoName):
+
+    is1D = "TH1" in histo.ClassName()
+
+    for axis, options in OPTIONSMAP[histoName].iteritems():
+
+        if axis == "X":
+            if "rebin" in options:
+                if is1D: histo.Rebin(options["rebin"])
+                else: histo.RebinX(options["rebin"])
+            if "min" in options and "max" in options: histo.GetXaxis().SetRangeUser(options["min"],options["max"])
+            if "title" in options: histo.GetXaxis().SetTitle(options["title"])
+        if axis == "Y":
+            if "rebin" in options:
+                if is1D: histo.Rebin(options["rebin"])
+                else: histo.RebinY(options["rebin"])
+            if "min" in options and "max" in options: histo.GetYaxis().SetRangeUser(options["min"],options["max"])
+            if "title" in options: histo.GetYaxis().SetTitle(options["title"])
+        if axis == "Z":
+            if "min" in options and "max" in options: histo.GetZaxis().SetRangeUser(options["min"],options["max"])
+
+def prettyHisto(histo,magicFactor=1.0,magicFactor2=1.0):
+    histo.GetYaxis().SetLabelSize(magicFactor*0.055); histo.GetYaxis().SetTitleSize(magicFactor*0.08); histo.GetYaxis().SetTitleOffset(0.7/magicFactor)
+    histo.GetXaxis().SetLabelSize(magicFactor*0.055); histo.GetXaxis().SetTitleSize(magicFactor*0.08); histo.GetXaxis().SetTitleOffset(0.8/magicFactor2)
+    histo.GetZaxis().SetLabelSize(magicFactor*0.055); histo.GetZaxis().SetTitleSize(magicFactor*0.06)
+
+def fillMap(inRootFile, theMap):
+
+    if ".root" not in inRootFile: return
+    histoFile = ROOT.TFile.Open(inRootFile, "READ")
+    for hkey in histoFile.GetListOfKeys():
+        if "TH" not in hkey.GetClassName(): continue
+
+        if hkey.GetName() == "EventCounter": continue
+
+        keyStubs = hkey.GetName().split("_")
+
+        mva = keyStubs[-2]
+        variation = keyStubs[-1]
+
+        # Little corner case...
+        if mva == "hemcorr":
+            mva = variation
+            variation = "hemcorr"
+
+        histo = hkey.ReadObj()
+        histo.SetDirectory(0)
+
+        histo.Sumw2()
+        
+        theMap.setdefault(mva, {}).setdefault(variation, histo)
+
+if __name__ == '__main__':
+
+    XCANVAS = 2400; YCANVAS = 2400
+
+    if arg.inputDir == "NULL": quit()
+    stub = arg.inputDir.split("condor/")[-1].split(".root")[0].split("_")[-1]
+
+    inRootFile = arg.inputDir
+       
+    outpath = "./plots/NJetsStudy/%s/"%(stub)
+    if not os.path.exists(outpath): os.makedirs(outpath)
+
+    mapPFAhistos = {}
+
+    fillMap(inRootFile, mapPFAhistos)
+
+    mvas = ["d1", "d2", "d3", "d4"]
+    # Save the final histograms
+    for mva in mvas:
+
+        hemCorr = mapPFAhistos[mva]["hemcorr"]; prettyHisto(hemCorr)
+        JECUp = mapPFAhistos[mva]["JECup"]; prettyHisto(JECUp)
+        JECDown = mapPFAhistos[mva]["JECdown"]; prettyHisto(JECDown)
+        JERUp = mapPFAhistos[mva]["JERup"]; prettyHisto(JERUp)
+        JERDown = mapPFAhistos[mva]["JERdown"]; prettyHisto(JERDown)
+        totUp = mapPFAhistos[mva]["up"]; prettyHisto(totUp)
+        totDown = mapPFAhistos[mva]["down"]; prettyHisto(totDown)
+
+        XMin = 0; XMax = 1
+        YMin = 0; YMax = 1
+
+        JECUp.SetTitle("");   JECUp.Scale(1./JECUp.Integral())
+        JECDown.SetTitle(""); JECDown.Scale(1./JECDown.Integral())
+        JERUp.SetTitle("");   JERUp.Scale(1./JERUp.Integral())
+        JERDown.SetTitle(""); JERDown.Scale(1./JERDown.Integral())
+        totUp.SetTitle("");   totUp.Scale(1./totUp.Integral())
+        totDown.SetTitle(""); totDown.Scale(1./totDown.Integral())
+
+        doOptions(hemCorr, "h_njets"); doOptions(JECUp, "h_njets"); doOptions(JECDown, "h_njets")
+
+        jecup, jecdown, jecband = makeBandGraph(JECUp, JECDown)
+        jerup, jerdown, jerband = makeBandGraph(JERUp, JERDown, ROOT.kBlue)
+        totup, totdown, totband = makeBandGraph(totUp, totDown, ROOT.kGreen+2)
+
+        hemCorr.SetTitle(""); hemCorr.SetMarkerColor(ROOT.kBlack); hemCorr.SetLineColor(ROOT.kBlack); hemCorr.SetMarkerSize(4); hemCorr.SetLineWidth(3); hemCorr.SetMarkerStyle(20); hemCorr.Scale(1./hemCorr.Integral())
+
+        hemCorr.SetNdivisions(16)
+
+        c1 = ROOT.TCanvas("%s"%(mva), "%s"%(mva), XCANVAS, YCANVAS); 
+        c1.cd(); ROOT.gPad.SetLogy(); ROOT.gPad.SetPad(XMin, YMin, XMax, YMax)
+
+        ROOT.gPad.SetGridy(); ROOT.gPad.SetGridx()
+        ROOT.gPad.SetTopMargin(0.03)
+        ROOT.gPad.SetLeftMargin(0.11)
+        ROOT.gPad.SetBottomMargin(0.15)
+        ROOT.gPad.SetRightMargin(0.04)
+
+        hemCorr.Draw()
+        jecband.Draw("F")
+        jecup.Draw("L")
+        jecdown.Draw("L")
+
+        jerband.Draw("F")
+        jerup.Draw("L")
+        jerdown.Draw("L")
+
+        c1.SaveAs("%s/%s_JECJER.pdf"%(outpath,mva))
+
+        c2 = ROOT.TCanvas("%s_tot"%(mva), "%s_tot"%(mva), XCANVAS, YCANVAS); 
+        c2.cd(); ROOT.gPad.SetLogy(); ROOT.gPad.SetPad(XMin, YMin, XMax, YMax)
+
+        ROOT.gPad.SetGridy(); ROOT.gPad.SetGridx()
+        ROOT.gPad.SetTopMargin(0.03)
+        ROOT.gPad.SetLeftMargin(0.11)
+        ROOT.gPad.SetBottomMargin(0.15)
+        ROOT.gPad.SetRightMargin(0.04)
+
+        hemCorr.Draw()
+        totband.Draw("F")
+        totup.Draw("L")
+        totdown.Draw("L")
+        hemCorr.Draw("EP SAME")
+
+        c2.SaveAs("%s/%s_total.pdf"%(outpath,mva))

--- a/Analyzer/test/finalNJetsRatioPlots.py
+++ b/Analyzer/test/finalNJetsRatioPlots.py
@@ -1,0 +1,127 @@
+import sys, os, ROOT, argparse
+from collections import defaultdict
+
+ROOT.TH1.SetDefaultSumw2()
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat("")
+ROOT.gStyle.SetPaintTextFormat("3.2f")
+ROOT.gStyle.SetFrameLineWidth(2)
+
+usage = "usage: %prog [options]"
+parser = argparse.ArgumentParser(usage)
+parser.add_argument("--inputDir", dest="inputDir", help="Path to input", default="NULL", type=str) 
+
+arg = parser.parse_args()
+
+OPTIONSMAP = {"h_njets_1l_HT300_ge7j_ge1b_Mbl_d1" : {"X" : {"min" : 7, "max" : 15, "title" : "N_{J} D1"}},
+              "h_njets_1l_HT300_ge7j_ge1b_Mbl_d2" : {"X" : {"min" : 7, "max" : 15, "title" : "N_{J} D2"}},
+              "h_njets_1l_HT300_ge7j_ge1b_Mbl_d3" : {"X" : {"min" : 7, "max" : 15, "title" : "N_{J} D3"}},
+              "h_njets_1l_HT300_ge7j_ge1b_Mbl_d4" : {"X" : {"min" : 7, "max" : 15, "title" : "N_{J} D4"}},
+              "h_njets_1l_HT300_ge7j_ge1b_Mbl"    : {"X" : {"min" : 7, "max" : 15, "title" : "N_{J}"}}
+}
+
+def doOptions(histo, histoName):
+
+    is1D = "TH1" in histo.ClassName()
+
+    for axis, options in OPTIONSMAP[histoName].iteritems():
+
+        if axis == "X":
+            if "rebin" in options:
+                if is1D: histo.Rebin(options["rebin"])
+                else: histo.RebinX(options["rebin"])
+            if "min" in options and "max" in options: histo.GetXaxis().SetRangeUser(options["min"],options["max"])
+            if "title" in options: histo.GetXaxis().SetTitle(options["title"])
+        if axis == "Y":
+            if "rebin" in options:
+                if is1D: histo.Rebin(options["rebin"])
+                else: histo.RebinY(options["rebin"])
+            if "min" in options and "max" in options: histo.GetYaxis().SetRangeUser(options["min"],options["max"])
+            if "title" in options: histo.GetYaxis().SetTitle(options["title"])
+        if axis == "Z":
+            if "min" in options and "max" in options: histo.GetZaxis().SetRangeUser(options["min"],options["max"])
+
+def prettyHisto(histo,magicFactor=1.0,magicFactor2=1.0):
+    histo.GetYaxis().SetLabelSize(magicFactor*0.055); histo.GetYaxis().SetTitleSize(magicFactor*0.08); histo.GetYaxis().SetTitleOffset(0.7/magicFactor)
+    histo.GetXaxis().SetLabelSize(magicFactor*0.055); histo.GetXaxis().SetTitleSize(magicFactor*0.08); histo.GetXaxis().SetTitleOffset(0.8/magicFactor2)
+    histo.GetZaxis().SetLabelSize(magicFactor*0.055); histo.GetZaxis().SetTitleSize(magicFactor*0.06)
+
+def fillMap(inRootFile, theMap):
+
+    if ".root" not in inRootFile: return
+    histoFile = ROOT.TFile.Open(inRootFile, "READ")
+    for hkey in histoFile.GetListOfKeys():
+        if "TH" not in hkey.GetClassName(): continue
+
+        if hkey.GetName() == "EventCounter" or hkey.GetName().find("njets") == -1: continue
+
+        histo = hkey.ReadObj()
+        histo.SetDirectory(0)
+
+        histo.Sumw2()
+        
+        theMap.setdefault(hkey.GetName(), histo)
+
+if __name__ == '__main__':
+
+    XCANVAS = 2400; YCANVAS = 2400
+
+    if arg.inputDir == "NULL": quit()
+    stub = arg.inputDir.split("condor/")[-1]
+
+    inRootFile = arg.inputDir + "/2017_MC.root"
+       
+    outpath = "./plots/%s/"%(stub)
+    if not os.path.exists(outpath): os.makedirs(outpath)
+
+    mapPFAhistos = {}
+
+    fillMap(inRootFile, mapPFAhistos)
+
+    # Save the final histograms
+
+    njetsD1 = mapPFAhistos["h_njets_1l_HT300_ge7j_ge1b_Mbl_d1"]; prettyHisto(njetsD1)
+    njetsD2 = mapPFAhistos["h_njets_1l_HT300_ge7j_ge1b_Mbl_d2"]; prettyHisto(njetsD2)
+    njetsD3 = mapPFAhistos["h_njets_1l_HT300_ge7j_ge1b_Mbl_d3"]; prettyHisto(njetsD3)
+    njetsD4 = mapPFAhistos["h_njets_1l_HT300_ge7j_ge1b_Mbl_d4"]; prettyHisto(njetsD4)
+
+    njets   = mapPFAhistos["h_njets_1l_HT300_ge7j_ge1b_Mbl"]; prettyHisto(njets)
+
+    XMin = 0; XMax = 1
+    YMin = 0; YMax = 1
+
+    njetsD1.SetTitle(""); njetsD1.Scale(1./njetsD1.Integral()); doOptions(njetsD1, "h_njets_1l_HT300_ge7j_ge1b_Mbl_d1")
+    njetsD2.SetTitle(""); njetsD2.Scale(1./njetsD2.Integral()); doOptions(njetsD2, "h_njets_1l_HT300_ge7j_ge1b_Mbl_d2")
+    njetsD3.SetTitle(""); njetsD3.Scale(1./njetsD3.Integral()); doOptions(njetsD3, "h_njets_1l_HT300_ge7j_ge1b_Mbl_d3")
+    njetsD4.SetTitle(""); njetsD4.Scale(1./njetsD4.Integral()); doOptions(njetsD4, "h_njets_1l_HT300_ge7j_ge1b_Mbl_d4")
+    njets.SetTitle("");   njets.Scale(1./njets.Integral());     doOptions(njets,   "h_njets_1l_HT300_ge7j_ge1b_Mbl")
+
+    njetsD1.Divide(njets); njetsD1.SetMinimum(0.50); njetsD1.SetMaximum(1.50); njetsD1.GetYaxis().SetNdivisions(308)
+    njetsD2.Divide(njets); njetsD2.SetMinimum(0.50); njetsD2.SetMaximum(1.50); njetsD2.GetYaxis().SetNdivisions(308)
+    njetsD3.Divide(njets); njetsD3.SetMinimum(0.50); njetsD3.SetMaximum(1.50); njetsD3.GetYaxis().SetNdivisions(308)
+    njetsD4.Divide(njets); njetsD4.SetMinimum(0.50); njetsD4.SetMaximum(1.50); njetsD4.GetYaxis().SetNdivisions(308)
+
+    njetsD1.SetMarkerColor(ROOT.kBlack);   njetsD1.SetLineColor(ROOT.kBlack);   njetsD1.SetMarkerSize(4); njetsD1.SetMarkerStyle(20); njetsD1.SetLineWidth(3)
+    njetsD2.SetMarkerColor(ROOT.kRed);     njetsD2.SetLineColor(ROOT.kRed);     njetsD2.SetMarkerSize(4); njetsD2.SetMarkerStyle(20); njetsD2.SetLineWidth(3)
+    njetsD3.SetMarkerColor(ROOT.kBlue);    njetsD3.SetLineColor(ROOT.kBlue);    njetsD3.SetMarkerSize(4); njetsD3.SetMarkerStyle(20); njetsD3.SetLineWidth(3)
+    njetsD4.SetMarkerColor(ROOT.kGreen+2); njetsD4.SetLineColor(ROOT.kGreen+2); njetsD4.SetMarkerSize(4); njetsD4.SetMarkerStyle(20); njetsD4.SetLineWidth(3)
+
+    mvaBins = ["D1", "D2", "D3", "D4"]
+
+    for mva in mvaBins:
+
+        c1 = ROOT.TCanvas("njets%s"%(mva), "njets%s"%(mva), XCANVAS, YCANVAS); 
+        c1.cd(); ROOT.gPad.SetPad(XMin, YMin, XMax, YMax)
+
+        ROOT.gPad.SetGridy(); ROOT.gPad.SetGridx()
+        ROOT.gPad.SetTopMargin(0.03)
+        ROOT.gPad.SetLeftMargin(0.11)
+        ROOT.gPad.SetBottomMargin(0.15)
+        ROOT.gPad.SetRightMargin(0.04)
+
+        if   mva == "D1": njetsD1.Draw("L")
+        elif mva == "D2": njetsD2.Draw("L")
+        elif mva == "D3": njetsD3.Draw("L")
+        elif mva == "D4": njetsD4.Draw("L")
+
+        c1.SaveAs("%s/njets%s_Total_Ratio.pdf"%(outpath,mva))

--- a/Analyzer/test/finalPUplots.py
+++ b/Analyzer/test/finalPUplots.py
@@ -1,0 +1,155 @@
+import sys, os, ROOT, argparse
+
+ROOT.TH1.SetDefaultSumw2()
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat("")
+ROOT.gStyle.SetFrameLineWidth(2)
+ROOT.gStyle.SetErrorX(0)
+
+usage = "usage: %prog [options]"
+parser = argparse.ArgumentParser(usage)
+parser.add_argument("--inputDir", dest="inputDir", help="Path to input directory"    , default="NULL", type=str) 
+parser.add_argument("--year"    , dest="year"    , help="What year are we looking at", default="NULL", type=str) 
+
+arg = parser.parse_args()
+
+OPTIONSMAP = {"h_njets_nvtx_1l_HT300_ge3j_ge1b_Mbl"              : {"X" : {"rebin" : 2,  "min" : 0, "max" : 100, "title" : "NVtx"}, "Y" : {"title" : "N_{J}"}},
+              "h_njets_nvtx_1l_HT300_ge3j_ge1b_Mbl_noPuWeight"   : {"X" : {"rebin" : 2,  "min" : 0, "max" : 100, "title" : "NVtx"}, "Y" : {"title" : "N_{J}"}},
+}
+
+def doOptions(histo, histoName):
+
+    is1D = "TH1" in histo.ClassName()
+
+    for axis, options in OPTIONSMAP[histoName].iteritems():
+
+        if axis == "X":
+            if "rebin" in options:
+                if is1D: histo.Rebin(options["rebin"])
+                else: histo.RebinX(options["rebin"])
+            if "min" in options and "max" in options: histo.GetXaxis().SetRangeUser(options["min"],options["max"])
+            if "title" in options: histo.GetXaxis().SetTitle(options["title"])
+        if axis == "Y":
+            if "rebin" in options:
+                if is1D: histo.Rebin(options["rebin"])
+                else: histo.RebinY(options["rebin"])
+            if "min" in options and "max" in options: histo.GetYaxis().SetRangeUser(options["min"],options["max"])
+            if "title" in options: histo.GetYaxis().SetTitle(options["title"])
+        if axis == "Z":
+            if "min" in options and "max" in options: histo.GetZaxis().SetRangeUser(options["min"],options["max"])
+
+def prettyHisto(histo,magicFactor=1.0,magicFactor2=1.0):
+    histo.GetYaxis().SetLabelSize(0.045); histo.GetYaxis().SetTitleSize(0.06); histo.GetYaxis().SetTitleOffset(0.8)
+    histo.GetXaxis().SetLabelSize(0.045); histo.GetXaxis().SetTitleSize(0.06); histo.GetXaxis().SetTitleOffset(0.8)
+    histo.GetZaxis().SetLabelSize(0.045); histo.GetZaxis().SetTitleSize(0.06)
+
+def fillMap(inRootFile, theMap):
+
+    keyName = inRootFile.split("_")[-1].split(".root")[0]
+
+    if ".root" not in inRootFile: return
+    histoFile = ROOT.TFile.Open(inRootFile, "READ")
+    for hkey in histoFile.GetListOfKeys():
+        if "TH" not in hkey.GetClassName(): continue
+
+        name = hkey.GetName()
+        if name not in OPTIONSMAP: continue
+
+        histo = hkey.ReadObj()
+        histo.SetDirectory(0)
+
+        histo.Sumw2()
+        
+        if name in theMap[keyName].keys(): theMap[keyName][name].Add(histo)
+        else: theMap[keyName][name] = histo
+
+if __name__ == '__main__':
+
+    XCANVAS = 2400; YCANVAS = 2400
+
+    inputDir = arg.inputDir
+    year     = arg.year
+
+    stub = ""
+    if inputDir == "NULL": quit()
+    else: stub = inputDir.split("/")[-1]
+
+    outpath = "./plots/AppendixC/%s/"%(stub)
+    if not os.path.exists(outpath): os.makedirs(outpath)
+
+    mapPFAhistos = {"TT" : {}, "Data" : {}}
+
+    ttbarFile = inputDir + "/%s_TT.root"%(year)
+    dataFile  = inputDir + "/%s_Data.root"%(year)
+
+    fillMap(ttbarFile, mapPFAhistos)
+    fillMap(dataFile,  mapPFAhistos)
+
+    # Save the final histograms
+    magicMargins = {"T" : 0.07, "B" : 0.11, "L" : 0.11, "R" : 0.13}
+
+    c1 = ROOT.TCanvas("Data_2D", "Data_2D", XCANVAS, YCANVAS); c1.cd(); c1.SetLogz()
+
+    ROOT.gPad.SetTopMargin(magicMargins["T"])
+    ROOT.gPad.SetBottomMargin(magicMargins["B"])
+    ROOT.gPad.SetLeftMargin(magicMargins["L"])
+    ROOT.gPad.SetRightMargin(magicMargins["R"])
+
+    nominalName = "h_njets_nvtx_1l_HT300_ge3j_ge1b_Mbl"; noPuWeightName = "h_njets_nvtx_1l_HT300_ge3j_ge1b_Mbl_noPuWeight" 
+    ttNominal    = mapPFAhistos["TT"][nominalName];    prettyHisto(ttNominal,0.875,1.1);    doOptions(ttNominal, nominalName);       ttNominal.SetTitle("NJets v Number of Vertices");    ttNominal.SetContour(255)
+    ttNoPuWeight = mapPFAhistos["TT"][noPuWeightName]; prettyHisto(ttNoPuWeight,0.875,1.1); doOptions(ttNoPuWeight, noPuWeightName); ttNoPuWeight.SetTitle("NJets v Number of Vertices"); ttNoPuWeight.SetContour(255)
+    data         = mapPFAhistos["Data"][nominalName];  prettyHisto(data,0.875,1.1);         doOptions(data, nominalName);            data.SetTitle("NJets v Number of Vertices");         data.SetContour(255)
+
+    ttNominalProf    = ttNominal.ProfileX("ttNominal", 1, -1, "");       ttNominalProf.SetLineColor(ROOT.kBlue);   ttNominalProf.SetMarkerColor(ROOT.kBlue);    ttNominalProf.SetLineWidth(3);    ttNominalProf.SetTitle("Comparison of Profile with and without PU Weights")
+    ttNoPuWeightProf = ttNoPuWeight.ProfileX("ttNoPuWeight", 1, -1, ""); ttNoPuWeightProf.SetLineColor(ROOT.kRed); ttNoPuWeightProf.SetMarkerColor(ROOT.kRed); ttNoPuWeightProf.SetLineWidth(3); ttNoPuWeightProf.SetTitle("Comparison of Profile with and without PU Weights")
+    dataProf         = data.ProfileX("data", 1, -1, "");                 dataProf.SetLineColor(ROOT.kBlue);        data.SetMarkerColor(ROOT.kCyan);             dataProf.SetLineWidth(3);         dataProf.SetTitle("Comparison of Profile with and without PU Weights")
+
+    data.Draw("COLZ")
+    dataProf.Draw("HIST SAME")
+
+    c1.SaveAs("%s/Data_NJets_vs_NVtx.pdf"%(outpath))
+
+    c3 = ROOT.TCanvas("TT_2D_nom", "TT_2D_nom", XCANVAS, YCANVAS); c3.cd(); c3.SetLogz()
+
+    ROOT.gPad.SetTopMargin(magicMargins["T"])
+    ROOT.gPad.SetBottomMargin(magicMargins["B"])
+    ROOT.gPad.SetLeftMargin(magicMargins["L"])
+    ROOT.gPad.SetRightMargin(magicMargins["R"])
+
+    ttNominal.Draw("COLZ")
+    ttNominalProf.Draw("HIST SAME")
+
+    c3.SaveAs("%s/TT_Nominal_NJets_vs_NVtx.pdf"%(outpath))
+
+    c4 = ROOT.TCanvas("TT_2D_noPU", "TT_2D_noPU", XCANVAS, YCANVAS); c4.cd(); c4.SetLogz()
+
+    ROOT.gPad.SetTopMargin(magicMargins["T"])
+    ROOT.gPad.SetBottomMargin(magicMargins["B"])
+    ROOT.gPad.SetLeftMargin(magicMargins["L"])
+    ROOT.gPad.SetRightMargin(magicMargins["R"])
+
+    ttNoPuWeight.Draw("COLZ")
+    ttNoPuWeightProf.Draw("HIST SAME")
+
+    c4.SaveAs("%s/TT_NoPuWeight_NJets_vs_NVtx.pdf"%(outpath))
+
+    c2 = ROOT.TCanvas("_1D", "_1D", XCANVAS, YCANVAS); c2.cd()
+
+    ROOT.gPad.SetTopMargin(magicMargins["T"])
+    ROOT.gPad.SetBottomMargin(magicMargins["B"])
+    ROOT.gPad.SetLeftMargin(magicMargins["L"])
+    ROOT.gPad.SetRightMargin(magicMargins["R"])
+
+    dataProf.SetLineColor(ROOT.kCyan)
+
+    ttNominalProf.SetMinimum(3)
+    ttNominalProf.SetMaximum(9)
+
+    iamLegend = ROOT.TLegend(0.12, 0.82, 0.55, 0.92)
+    iamLegend.AddEntry(ttNominalProf, "with PU weight")
+    iamLegend.AddEntry(ttNoPuWeightProf, "without PU weight")
+    iamLegend.AddEntry(dataProf, "Data")
+
+    ttNominalProf.Draw("HIST"); ttNoPuWeightProf.Draw("HIST SAME"); dataProf.Draw("HIST SAME"); iamLegend.Draw("SAME")
+
+    c2.SaveAs("%s/Profiles_Comparison.pdf"%(outpath))

--- a/Analyzer/test/finalTTbarNJetsPlots.py
+++ b/Analyzer/test/finalTTbarNJetsPlots.py
@@ -1,0 +1,128 @@
+import sys, os, ROOT, argparse
+
+ROOT.TH1.SetDefaultSumw2()
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat("")
+ROOT.gStyle.SetPaintTextFormat("3.2f")
+ROOT.gStyle.SetFrameLineWidth(2)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--tt2016", dest="tt2016", help="Path to 2016 fit input dir", default="NULL", type=str) 
+parser.add_argument("--tt2017", dest="tt2017", help="Path to 2017 fit input dir", default="NULL", type=str) 
+parser.add_argument("--tt2018pre", dest="tt2018pre", help="Path to 2018pre fit input dir", default="NULL", type=str) 
+parser.add_argument("--tt2018post", dest="tt2018post", help="Path to 2018post fit input dir", default="NULL", type=str) 
+arg = parser.parse_args()
+
+OPTIONSMAP = {"D1_TT_h_njets_pt30_1l" : {"X" : {"title" : "N_{J} (Shifted)"}, "Y" : {"min" : 2e-4, "max" : 2}},
+              "D2_TT_h_njets_pt30_1l" : {"X" : {"title" : "N_{J} (Shifted)"}, "Y" : {"min" : 2e-4, "max" : 2}},
+              "D3_TT_h_njets_pt30_1l" : {"X" : {"title" : "N_{J} (Shifted)"}, "Y" : {"min" : 2e-4, "max" : 2}},
+              "D4_TT_h_njets_pt30_1l" : {"X" : {"title" : "N_{J} (Shifted)"}, "Y" : {"min" : 2e-4, "max" : 2}}
+}
+
+def doOptions(histo, histoName):
+
+    is1D = "TH1" in histo.ClassName()
+
+    for axis, options in OPTIONSMAP[histoName].iteritems():
+
+        if axis == "X":
+            if "rebin" in options:
+                if is1D: histo.Rebin(options["rebin"])
+                else: histo.RebinX(options["rebin"])
+            if "min" in options and "max" in options: histo.GetXaxis().SetRangeUser(options["min"],options["max"])
+            if "title" in options: histo.GetXaxis().SetTitle(options["title"])
+        if axis == "Y":
+            if "rebin" in options:
+                if is1D: histo.Rebin(options["rebin"])
+                else: histo.RebinY(options["rebin"])
+            if "min" in options and "max" in options: histo.SetMinimum(options["min"]); histo.SetMaximum(options["max"])
+            if "title" in options: histo.GetYaxis().SetTitle(options["title"])
+        if axis == "Z":
+            if "min" in options and "max" in options: histo.GetZaxis().SetRangeUser(options["min"],options["max"])
+
+def prettyHisto(histo,magicFactor=1.0,magicFactor2=1.0):
+    histo.GetYaxis().SetLabelSize(0.055); histo.GetYaxis().SetTitleSize(0.06); histo.GetYaxis().SetTitleOffset(0.7)
+    histo.GetXaxis().SetLabelSize(0.055); histo.GetXaxis().SetTitleSize(0.06); histo.GetXaxis().SetTitleOffset(1.0)
+    histo.GetZaxis().SetLabelSize(0.055); histo.GetZaxis().SetTitleSize(0.06)
+
+def fillMap(inRootFile, year):
+
+    if ".root" not in inRootFile: return
+    histoFile = ROOT.TFile.Open(inRootFile, "READ")
+    for hkey in histoFile.GetListOfKeys():
+
+        name = hkey.GetName()
+        spec = name.split("_")[-1].split(".")[0]
+        
+        if "TH" not in hkey.GetClassName(): continue
+        if name == "EventCounter": continue
+        if "_TT_" not in name or spec != "1l": continue
+
+        histo = hkey.ReadObj()
+        histo.SetDirectory(0)
+        ROOT.SetOwnership(histo, False)
+
+        histo.Sumw2()
+        
+        if name in MAPPFAHISTOS[year].keys(): MAPPFAHISTOS[year][name].Add(histo)
+        else: MAPPFAHISTOS[year][name] = histo
+
+if __name__ == '__main__':
+
+    XCANVAS = 2400; YCANVAS = 2400
+
+    tt2016 = arg.tt2016; tt2017 = arg.tt2017; tt2018pre = arg.tt2018pre; tt2018post = arg.tt2018post
+
+    if arg.tt2016 == "NULL" or arg.tt2017 == "NULL" or arg.tt2018pre == "NULL" or arg.tt2018post == "NULL": quit()
+
+    outpath = "./plots/NJetsTTbar/"
+    if not os.path.exists(outpath): os.makedirs(outpath)
+
+    MAPPFAHISTOS = {"2016" : {}, "2017" : {}, "2018pre" : {}, "2018post" : {}}
+
+    fillMap(arg.tt2016,     "2016")
+    fillMap(arg.tt2017,     "2017")
+    fillMap(arg.tt2018pre,  "2018pre")
+    fillMap(arg.tt2018post, "2018post")
+
+    # Save the final histograms
+    for name in MAPPFAHISTOS.values()[0].keys():
+
+        c1 = ROOT.TCanvas("%s"%(name), "%s"%(name), XCANVAS, YCANVAS); 
+        c1.cd(); ROOT.gPad.SetLogy(); ROOT.gPad.SetLogz()
+
+        ROOT.gPad.SetGridy(); ROOT.gPad.SetGridx()
+        ROOT.gPad.SetTopMargin(0.03)
+        ROOT.gPad.SetLeftMargin(0.11)
+        ROOT.gPad.SetBottomMargin(0.13)
+        ROOT.gPad.SetRightMargin(0.04)
+
+        tt2016 = MAPPFAHISTOS["2016"][name]; tt2017 = MAPPFAHISTOS["2017"][name]; tt2018pre = MAPPFAHISTOS["2018pre"][name]; tt2018post = MAPPFAHISTOS["2018post"][name]
+
+        prettyHisto(tt2016); prettyHisto(tt2017); prettyHisto(tt2018pre); prettyHisto(tt2018post)
+
+        theName = tt2016.GetName().replace("_2016", "")
+
+        tt2016.SetMarkerColor(ROOT.kBlack);       tt2016.SetLineColor(ROOT.kBlack);       tt2016.SetMarkerSize(4);     tt2016.SetLineWidth(4);     tt2016.SetMarkerStyle(20);     tt2016.Scale(1./tt2016.Integral())
+        tt2017.SetMarkerColor(ROOT.kBlue);        tt2017.SetLineColor(ROOT.kBlue);        tt2017.SetMarkerSize(4);     tt2017.SetLineWidth(4);     tt2017.SetMarkerStyle(20);     tt2017.Scale(1./tt2017.Integral())
+        tt2018pre.SetMarkerColor(ROOT.kRed);      tt2018pre.SetLineColor(ROOT.kRed);      tt2018pre.SetMarkerSize(4);  tt2018pre.SetLineWidth(4);  tt2018pre.SetMarkerStyle(20);  tt2018pre.Scale(1./tt2018pre.Integral())
+        tt2018post.SetMarkerColor(ROOT.kGreen+2); tt2018post.SetLineColor(ROOT.kGreen+2); tt2018post.SetMarkerSize(4); tt2018post.SetLineWidth(4); tt2018post.SetMarkerStyle(20); tt2018post.Scale(1./tt2018post.Integral())
+
+        if theName in OPTIONSMAP: doOptions(tt2016, theName); doOptions(tt2017, theName); doOptions(tt2018pre, theName); doOptions(tt2018post, theName)
+
+        tt2016.SetTitle(""); tt2017.SetTitle(""); tt2018pre.SetTitle(""); tt2018post.SetTitle("")
+
+        iamLegend = ROOT.TLegend(0.70, 0.6, 0.9, 0.95) 
+        iamLegend.SetLineWidth(0)
+        iamLegend.AddEntry(tt2016, "2016")
+        iamLegend.AddEntry(tt2017, "2017")
+        iamLegend.AddEntry(tt2018pre, "2018pre")
+        iamLegend.AddEntry(tt2018post, "2018post")
+
+        tt2016.Draw("EP"); #tt2016.Draw("HIST SAME")
+        tt2017.Draw("EP SAME"); #tt2017.Draw("HIST SAME")
+        tt2018pre.Draw("EP SAME"); #tt2018pre.Draw("HIST SAME")
+        tt2018post.Draw("EP SAME"); #tt2018post.Draw("HIST SAME")
+        iamLegend.Draw("SAME")
+
+        c1.SaveAs("%s/%s.pdf"%(outpath,name))

--- a/Analyzer/test/triggerPlotter.py
+++ b/Analyzer/test/triggerPlotter.py
@@ -10,11 +10,11 @@ ROOT.TH2.SetDefaultSumw2()
 
 usage = "usage: %prog [options]"
 parser = argparse.ArgumentParser(usage)
-parser.add_argument("--tag"    , dest="tag"    , help="Unique tag for output"         , type=str, required=True)
-parser.add_argument("--data"   , dest="data"   , help="full path to input data file"  , type=str, required=True)
-parser.add_argument("--mc"     , dest="mc"     , help="full path to input mc file"    , type=str, required=True)
-parser.add_argument("--year"   , dest="year"   , help="Which year of run II"          , type=str, required=True)
-parser.add_argument("--dataset", dest="dataset", help="The muon or electron dataset"  , type=str, required=True)
+parser.add_argument("--tag"      , dest="tag"      , help="Unique tag for output"         , type=str, required=True)
+parser.add_argument("--year"     , dest="year"     , help="Which year of run II"          , type=str, required=True)
+parser.add_argument("--basePath" , dest="basePath" , help="Base path to input"            , type=str, required=True)
+parser.add_argument("--inputDir" , dest="inputDir" , help="Dir in base path with files"   , type=str, required=True)
+parser.add_argument("--dataset"  , dest="dataset"  , help="The muon or electron dataset"  , type=str, required=True)
 
 arg = parser.parse_args()
 
@@ -215,12 +215,20 @@ if __name__ == '__main__':
     trigTags     = [ "trig" ] 
     nJetCutTags  = [ "5", "6" ]
 
-    mcFile = ROOT.TFile.Open(arg.mc)
-    dataFile = ROOT.TFile.Open(arg.data)
-
+    basePath = arg.basePath
+    inputDir = arg.inputDir
     tag = arg.tag
     year = arg.year
     dataset = arg.dataset
+
+    fullPath = basePath + "/" + inputDir
+
+    mcFile = ROOT.TFile.Open(fullPath + "/" + year + "_TT.root")
+
+    dataFile = 0
+    if dataset == "electron": dataFile = ROOT.TFile.Open(fullPath + "/" + year + "_Data_SingleElectron.root")
+    elif dataset == "muon": dataFile = ROOT.TFile.Open(fullPath + "/" + year + "_Data_SingleMuon.root")
+
 
     outputPath = "./plots/%s/%s"%(tag,arg.year)
     outputFileName = "%s_TrigEff.root"%(year)


### PR DESCRIPTION
finalEEplots.py : Small stylistic, plot aesthetic changes.
finalHEMstudy.py : Make njet vs mva bin plots for full, partial and no HEM veto.
finalNJetsPlots.py : Make JEC and JER band for njet distribution and put njet from JetMET-recipe-inspired jet collection
finalNJetsRatioPlots.py : Make njets per-mva bin / njet total for all four mva bins
finalPUplots.py : Make plots found in appendix C
finalTTbarNJetsPlots.py : Compare per-mva njets shape for all four years in ttbar.
triggerPlotter.py : Make things easier for the user when giving command-line options.