### PR TITLE
Update makefilelist.py

### DIFF
--- a/Analyzer/test/makefilelist.py
+++ b/Analyzer/test/makefilelist.py
@@ -72,7 +72,7 @@ else:
             # for data: Run2016B-17Jul2018_ver2-v1.SingleMuon_106_RA2AnalysisTree.root
             # for 2017 MC: RunIIFall17MiniAODv2.TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8_123_RA2AnalysisTree.root
             shortline = line.split(".")[1].rpartition("_")[0].rpartition("_")[0]
-            shortline = era+shortline.replace("_ext1","").replace("_ext2","").replace("_ext3","").replace("_backup","")
+            shortline = era+shortline.replace("_ext1","").replace("_ext2","").replace("_ext3","").replace("_backup","").replace("mN1", "mSo").replace("CUEP", "CUETP")
             print shortline
             newline = "root://cmseos.fnal.gov/" + basedir + line
             samples[shortline].append(newline)


### PR DESCRIPTION
Add replace command so "CUEP" gets associated with "CUETP".
Do the same for "mN1" so it gets mapped to "mSo".

This is only a feature for signal files. With this all signal lists will use mSo and CUETP where applicable.