### PR TITLE
Rewrite script that makes plots of systematics

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,5 +146,5 @@ cd $HOME/../../CMSSW_8_1_0/src/HiggsAnalysis/CombinedLimit/
 cd $HOME/../../CMSSW_9_3_3/src/Analyzer/Analyzer/test/
 
 # For example running on 2018pre
-python njets_systs_comp.py --year 2018pre --fitdir $HOME/../../src/HiggsAnalysis/CombinedLimit/ --fittag Approval_StatErrPlusFullDev_12JetFix
+python njets_systs_comp.py --year 2018pre --fitdir $HOME/../../src/HiggsAnalysis/CombinedLimit/ --fittag Approval_StatErrPlusFullDev_12JetFix --outputdir MYDIR
 ```


### PR DESCRIPTION
The njets_systs_comp script has been completely overhauled to provide for robustness. There is no more egregious copy-and-pasting of code blocks, as a single SystematicComputer class is used to keep track of common information about a given systematic. Likewise, I have tried to provide comments throughout---to the point of obviousness---for better transparency of what the code does.

I have tested the script and I have been able to reproduce results for systematics that use just raw (symmetrized) double ratios, systematics that use double ratios with fit njets shapes, and systematics which use double ratios of fit njets shapes that are then "quasi-symmetrized".