### PR TITLE
Fixed the memory leak problem to test the top tagger jet mask

### DIFF
--- a/Analyzer/src/AnalyzeTopTagger.cc
+++ b/Analyzer/src/AnalyzeTopTagger.cc
@@ -19,7 +19,7 @@
 #include "Framework/Framework/include/SetUpTopTagger.h"
 
 AnalyzeTopTagger::AnalyzeTopTagger() : hists("histos"), histNjet7("Njet7"), histNjet8("Njet8"), histNjet9("Njet9"), histNjet10("Njet10"), histNjet11("Njet11"), 
-                                                        histNjet12("Njet12"), histNjet13("Njet13"), histNjet14("Njet14"), histNjet15("Njet15") 
+                                                        histNjet12("Njet12"), histNjet13("Njet13"), histNjet14("Njet14"), histNjet15("Njet15")
 {
     InitHistos();
 }
@@ -175,6 +175,8 @@ void AnalyzeTopTagger::Loop(NTupleReader& tr, double, int maxevents, bool)
 
 void AnalyzeTopTagger::WriteHistos(TFile* outfile)
 {
+    outfile->cd();
+
     for (const auto &p : my_histos) {
         p.second->Write();
     }
@@ -197,6 +199,6 @@ void AnalyzeTopTagger::WriteHistos(TFile* outfile)
     histNjet13.save(outfile);
     histNjet14.save(outfile);
     histNjet15.save(outfile);
-    outfile->Write();
+    //outfile->Write();
     outfile->Close();
 }

--- a/Analyzer/src/Semra_Analyzer.cc
+++ b/Analyzer/src/Semra_Analyzer.cc
@@ -33,40 +33,43 @@ void Semra_Analyzer::InitHistos(const std::map<std::string, bool>& cutmap) // de
         // --------------------------------------
         // -- variables for baseline selection
         // --------------------------------------
-        //my_histos.emplace( "h_ntops_"+cutVar.first, std::make_shared<TH1D> ( ("h_ntops_"+cutVar.first).c_str(), ("h_ntops_"+cutVar.first).c_str(), 10, 0, 10 ) );
-        //my_histos.emplace( "h_njets_"+cutVar.first, std::make_shared<TH1D> ( ("h_njets_"+cutVar.first).c_str(), ("h_njets_"+cutVar.first).c_str(), 20, 0, 20 ) );
-        //my_histos.emplace( "h_nbjets_"+cutVar.first, std::make_shared<TH1D> ( ("h_nbjets_"+cutVar.first).c_str(), ("h_nbjets_"+cutVar.first).c_str(), 20, 0, 20 ) );
-        //my_histos.emplace( "h_ht_"+cutVar.first, std::make_shared<TH1D> ( ("h_ht_"+cutVar.first).c_str(), ("h_ht_"+cutVar.first).c_str(), 60, 0, 3000 ) );
-        //my_histos.emplace( "h_met_"+cutVar.first, std::make_shared<TH1D> ( ("h_met_"+cutVar.first).c_str(), ("h_met_"+cutVar.first).c_str(), 200, 0, 2000 ) ) ;
+        my_histos.emplace( "h_ntops_"+cutVar.first, std::make_shared<TH1D> ( ("h_ntops_"+cutVar.first).c_str(), ("h_ntops_"+cutVar.first).c_str(), 10, 0, 10 ) );
+        my_histos.emplace( "h_njets_"+cutVar.first, std::make_shared<TH1D> ( ("h_njets_"+cutVar.first).c_str(), ("h_njets_"+cutVar.first).c_str(), 20, 0, 20 ) );
+        my_histos.emplace( "h_nbjets_"+cutVar.first, std::make_shared<TH1D> ( ("h_nbjets_"+cutVar.first).c_str(), ("h_nbjets_"+cutVar.first).c_str(), 20, 0, 20 ) );
+        my_histos.emplace( "h_ht_"+cutVar.first, std::make_shared<TH1D> ( ("h_ht_"+cutVar.first).c_str(), ("h_ht_"+cutVar.first).c_str(), 60, 0, 3000 ) );
+        my_histos.emplace( "h_met_"+cutVar.first, std::make_shared<TH1D> ( ("h_met_"+cutVar.first).c_str(), ("h_met_"+cutVar.first).c_str(), 200, 0, 2000 ) ) ;
         //my_histos.emplace( "h_jetsPt_"+cutVar.first, std::make_shared<TH1D> ( ("h_jetsPt_"+cutVar.first).c_str(), ("h_jetsPt_"+cutVar.first).c_str(), 1000, 0, 2000 ) );
         //my_histos.emplace( "h_jetsMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_jetsMass_"+cutVar.first).c_str(), ("h_jetsMass_"+cutVar.first).c_str(), 1000, 0, 500) );
         //my_histos.emplace( "h_bjetsPt_"+cutVar.first, std::make_shared<TH1D> ( ("h_bjetsPt_"+cutVar.first).c_str(), ("h_bjetsPt_"+cutVar.first).c_str(), 1000, 0, 2000 ) );
         //my_histos.emplace( "h_bjetsMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_bjetsMass_"+cutVar.first).c_str(), ("h_bjetsMass_"+cutVar.first).c_str(), 1000, 0, 500 ) );
         
         // get the top object (actual top jets from top TLorentzVector) jets' Mass, Eta, Phi, Pt  
-        //my_histos.emplace( "h_topsMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_topsMass_"+cutVar.first).c_str(), ("h_topsMass_"+cutVar.first).c_str(), 1000, 0, 500 ) );
-        //my_histos.emplace( "h_topsEta_"+cutVar.first, std::make_shared<TH1D> ( ("h_topsEta_"+cutVar.first).c_str(), ("h_topsEta_"+cutVar.first).c_str(), 100, -6, 6 ) );
-        //my_histos.emplace( "h_topsPhi_"+cutVar.first, std::make_shared<TH1D> ( ("h_topsPhi_"+cutVar.first).c_str(), ("h_topsPhi_"+cutVar.first).c_str(), 80, -4, 4 ) );
-        //my_histos.emplace( "h_topsPt_"+cutVar.first, std::make_shared<TH1D> ( ("h_topsPt_"+cutVar.first).c_str(), ("h_topsPt_"+cutVar.first).c_str(), 1000, 0, 2000 ) );
+        my_histos.emplace( "h_topsMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_topsMass_"+cutVar.first).c_str(), ("h_topsMass_"+cutVar.first).c_str(), 1000, 0, 500 ) );
+        my_histos.emplace( "h_topsEta_"+cutVar.first, std::make_shared<TH1D> ( ("h_topsEta_"+cutVar.first).c_str(), ("h_topsEta_"+cutVar.first).c_str(), 100, -6, 6 ) );
+        my_histos.emplace( "h_topsPhi_"+cutVar.first, std::make_shared<TH1D> ( ("h_topsPhi_"+cutVar.first).c_str(), ("h_topsPhi_"+cutVar.first).c_str(), 80, -4, 4 ) );
+        my_histos.emplace( "h_topsPt_"+cutVar.first, std::make_shared<TH1D> ( ("h_topsPt_"+cutVar.first).c_str(), ("h_topsPt_"+cutVar.first).c_str(), 1000, 0, 2000 ) );
 
-        // get the resolved jets' Mass, Eta, Phi, Pt
-        //my_histos.emplace( "h_resolvedMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_resolvedMass_"+cutVar.first).c_str(), ("h_resolvedMass_"+cutVar.first).c_str(), 500, 0, 1500) );
-        //my_histos.emplace( "h_resolvedEta_"+cutVar.first, std::make_shared<TH1D> ( ("h_resolvedEta_"+cutVar.first).c_str(), ("h-resolvedEta_"+cutVar.first).c_str(), 100, -6, 6 ) );
-        //my_histos.emplace( "h_resolvedPhi_"+cutVar.first, std::make_shared<TH1D> ( ("h_resolvedPhi_"+cutVar.first).c_str(), ("h_resolvedPhi_"+cutVar.first).c_str(), 80, -4, 4 ) );
-        //my_histos.emplace( "h_resolvedPt_"+cutVar.first, std::make_shared<TH1D> ( ("h_resolvedPt_"+cutVar.first).c_str(), ("h_resolvedPt_"+cutVar.first).c_str(), 100, 0, 1000 ) );
+        // get the each resolved jets' Mass, Eta, Phi, Pt 
+        my_histos.emplace( "h_resolvedMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_resolvedMass_"+cutVar.first).c_str(), ("h_resolvedMass_"+cutVar.first).c_str(), 500, 0, 1500) );
+        my_histos.emplace( "h_resolvedEta_"+cutVar.first, std::make_shared<TH1D> ( ("h_resolvedEta_"+cutVar.first).c_str(), ("h-resolvedEta_"+cutVar.first).c_str(), 100, -6, 6 ) );
+        my_histos.emplace( "h_resolvedPhi_"+cutVar.first, std::make_shared<TH1D> ( ("h_resolvedPhi_"+cutVar.first).c_str(), ("h_resolvedPhi_"+cutVar.first).c_str(), 80, -4, 4 ) );
+        my_histos.emplace( "h_resolvedPt_"+cutVar.first, std::make_shared<TH1D> ( ("h_resolvedPt_"+cutVar.first).c_str(), ("h_resolvedPt_"+cutVar.first).c_str(), 100, 0, 1000 ) );
 
-        //my_histos.emplace( "h_bestTopMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_bestTopMass_"+cutVar.first).c_str(), ("h_bestTopMass_"+cutVar.first).c_str(), 1000, 0, 500 ) );
-        //my_histos.emplace( "h_bestTopEta_"+cutVar.first, std::make_shared<TH1D> ( ("h_bestTopEta_"+cutVar.first).c_str(), ("h_bestTopEta_"+cutVar.first).c_str(), 100, -6, 6 ) );
-        //my_histos.emplace( "h_bestTopPt_"+cutVar.first, std::make_shared<TH1D> ( ("h_bestTopPt_"+cutVar.first).c_str(), ("h_bestTopPt_"+cutVar.first).c_str(), 1000, 0, 2000 ) );
-        //my_histos.emplace( "h_dR_bjet1_bjet2_"+cutVar.first, std::make_shared<TH1D> ( ("h_dR_bjet1_bjet2_"+cutVar.first).c_str(), ("h_dR_bjet1_bjet2_"+cutVar.first).c_str(), 50, 0, 10 ) );
-        //my_histos.emplace( "h_dR_top1_top2_"+cutVar.first, std::make_shared<TH1D> ( ("h_dR_top1_top2_"+cutVar.first).c_str(), ("h_dR_top1_top2_"+cutVar.first).c_str(), 50, 0, 10 ) );
-        //my_histos.emplace( "h_dR_tops_bjets_"+cutVar.first, std::make_shared<TH1D> ( ("h_dR_tops_bjets_"+cutVar.first).c_str(), ("h_dR_tops_bjets_"+cutVar.first).c_str(), 50, 0, 10 ) );
+        my_histos.emplace( "h_bestTopMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_bestTopMass_"+cutVar.first).c_str(), ("h_bestTopMass_"+cutVar.first).c_str(), 1000, 0, 500 ) );
+        my_histos.emplace( "h_bestTopEta_"+cutVar.first, std::make_shared<TH1D> ( ("h_bestTopEta_"+cutVar.first).c_str(), ("h_bestTopEta_"+cutVar.first).c_str(), 100, -6, 6 ) );
+        my_histos.emplace( "h_bestTopPt_"+cutVar.first, std::make_shared<TH1D> ( ("h_bestTopPt_"+cutVar.first).c_str(), ("h_bestTopPt_"+cutVar.first).c_str(), 1000, 0, 2000 ) );
+        
+        my_histos.emplace( "h_dR_bjets_"+cutVar.first, std::make_shared<TH1D> ( ("h_dR_bjets_"+cutVar.first).c_str(), ("h_dR_bjets_"+cutVar.first).c_str(), 50, 0, 10 ) );
+        my_histos.emplace( "h_dR_top1_top2_"+cutVar.first, std::make_shared<TH1D> ( ("h_dR_top1_top2_"+cutVar.first).c_str(), ("h_dR_top1_top2_"+cutVar.first).c_str(), 50, 0, 10 ) );
+        my_histos.emplace( "h_dR_tops_bjets_"+cutVar.first, std::make_shared<TH1D> ( ("h_dR_tops_bjets_"+cutVar.first).c_str(), ("h_dR_tops_bjets_"+cutVar.first).c_str(), 50, 0, 10 ) );
+
         //my_2d_histos.emplace( "h_njets_MVA_"+cutVar.first, std::make_shared<TH2D>( ("h_njets_MVA_"+cutVar.first).c_str(), ("h_njets_MVA_"+cutVar.first).c_str(), 8, 7, 15, 50, 0, 1.0 ) );
         //my_2d_histos.emplace( "h_njets_dR_bjets_"+cutVar.first, std::make_shared<TH2D>( ("h_njets_dR_bjets_"+cutVar.first).c_str(), ("h_njets_dR_bjets_"+cutVar.first).c_str(), 1000, 0, 10, 20, 0, 20 ) ); // for cut optimization of dR_bjets cut                   
 
         // --------------------------
         // -- stop MT2 hemispheres  
         // --------------------------
+        // pt rank 
         //my_histos.emplace( "h_stop1Mass_PtRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop1Mass_PtRank_"+cutVar.first).c_str(), ("h_stop1Mass_PtRank_"+cutVar.first).c_str(), 500, 0, 1500) );
         //my_histos.emplace( "h_stop1Eta_PtRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop1Eta_PtRank_"+cutVar.first).c_str(), ("h_stop1Eta_PtRank_"+cutVar.first).c_str(), 100, -6, 6 ) );
         //my_histos.emplace( "h_stop1Phi_PtRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop1Phi_PtRank_"+cutVar.first).c_str(), ("h_stop1Phi_PtRank_"+cutVar.first).c_str(), 80, -4, 4 ) );
@@ -75,6 +78,7 @@ void Semra_Analyzer::InitHistos(const std::map<std::string, bool>& cutmap) // de
         //my_histos.emplace( "h_stop2Eta_PtRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop2Eta_PtRank_"+cutVar.first).c_str(), ("h_stop2Eta_PtRank_"+cutVar.first).c_str(), 100, -6, 6 ) );
         //my_histos.emplace( "h_stop2Phi_PtRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop2Phi_PtRank_"+cutVar.first).c_str(), ("h_stop2Phi_PtRank_"+cutVar.first).c_str(), 80, -4, 4 ) );
         //my_histos.emplace( "h_stop2Pt_PtRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop2Pt_PtRank_"+cutVar.first).c_str(), ("h_stop2Pt_PtRank_"+cutVar.first).c_str(), 100, 0, 1000 ) );
+        // mass rank
         //my_histos.emplace( "h_stop1Mass_MassRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop1Mass_MassRank_"+cutVar.first).c_str(), ("h_stop1Mass_MassRank_"+cutVar.first).c_str(), 500, 0, 1500) );
         //my_histos.emplace( "h_stop1Eta_MassRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop1Eta_MassRank_"+cutVar.first).c_str(), ("h_stop1Eta_MassRank_"+cutVar.first).c_str(), 100, -6, 6 ) );
         //my_histos.emplace( "h_stop1Phi_MassRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop1Phi_MassRank_"+cutVar.first).c_str(), ("h_stop1Phi_MassRank_"+cutVar.first).c_str(), 80, -4, 4 ) );
@@ -83,6 +87,7 @@ void Semra_Analyzer::InitHistos(const std::map<std::string, bool>& cutmap) // de
         //my_histos.emplace( "h_stop2Eta_MassRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop2Eta_MassRank_"+cutVar.first).c_str(), ("h_stop2Eta_MassRank_"+cutVar.first).c_str(), 100, -6, 6 ) );
         //my_histos.emplace( "h_stop2Phi_MassRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop2Phi_MassRank_"+cutVar.first).c_str(), ("h_stop2Phi_MassRank_"+cutVar.first).c_str(), 80, -4, 4 ) );
         //my_histos.emplace( "h_stop2Pt_MassRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop2Pt_MassRank_"+cutVar.first).c_str(), ("h_stop2Pt_MassRank_"+cutVar.first).c_str(), 100, 0, 1000 ) );
+        // scalarPt rank
         //my_histos.emplace( "h_stop1Mass_ScalarPtRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop1Mass_ScalarPtRank_"+cutVar.first).c_str(), ("h_stop1Mass_ScalarPtRank_"+cutVar.first).c_str(), 500, 0, 1500) );
         //my_histos.emplace( "h_stop1Eta_ScalarPtRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop1Eta_ScalarPtRank_"+cutVar.first).c_str(), ("h_stop1Eta_ScalarPtRank_"+cutVar.first).c_str(), 100, -6, 6 ) );
         //my_histos.emplace( "h_stop1Phi_ScalarPtRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop1Phi_ScalarPtRank_"+cutVar.first).c_str(), ("h_stop1Phi_ScalarPtRank_"+cutVar.first).c_str(), 80, -4, 4 ) );
@@ -91,8 +96,10 @@ void Semra_Analyzer::InitHistos(const std::map<std::string, bool>& cutmap) // de
         //my_histos.emplace( "h_stop2Eta_ScalarPtRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop2Eta_ScalarPtRank_"+cutVar.first).c_str(), ("h_stop2Eta_ScalarPtRank_"+cutVar.first).c_str(), 100, -6, 6 ) );
         //my_histos.emplace( "h_stop2Phi_ScalarPtRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop2Phi_ScalarPtRank_"+cutVar.first).c_str(), ("h_stop2Phi_ScalarPtRank_"+cutVar.first).c_str(), 80, -4, 4 ) );
         //my_histos.emplace( "h_stop2Pt_ScalarPtRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop2Pt_ScalarPtRank_"+cutVar.first).c_str(), ("h_stop2Pt_ScalarPtRank_"+cutVar.first).c_str(), 100, 0, 1000 ) );       
+        
         //my_histos.emplace( "h_stop1ScalarPt_ScalarPtRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop1ScalarPt_ScalarPtRank_"+cutVar.first).c_str(), ("h_stop1ScalarPt_ScalarPtRank_"+cutVar.first).c_str(), 100, 0, 1000 ) );
         //my_histos.emplace( "h_stop2ScalarPt_ScalarPtRank_"+cutVar.first, std::make_shared<TH1D> ( ("h_stop2ScalarPt_ScalarPtRank_"+cutVar.first).c_str(), ("h_stop2ScalarPt_ScalarPtRank_"+cutVar.first).c_str(), 100, 0, 1000 ) );
+        
         //my_histos.emplace( "h_MT2_"+cutVar.first, std::make_shared<TH1D> ( ("h_MT2_"+cutVar.first).c_str(), ("h_MT2_"+cutVar.first).c_str(), 500, 0, 1500) );
         //my_histos.emplace( "h_dR_stop1stop2_"+cutVar.first, std::make_shared<TH1D> ( ("h_dR_stop1stop2_"+cutVar.first).c_str(), ("h_dR_stop1stop2_"+cutVar.first).c_str(), 50, 0, 10 ) );
         //my_histos.emplace( "h_dPhi_stop1stop2_"+cutVar.first, std::make_shared<TH1D> ( ("h_dPhi_stop1stop2_"+cutVar.first).c_str(), ("h_dPhi_stop1stop2_"+cutVar.first).c_str(), 50, 0, 10 ) );
@@ -101,14 +108,17 @@ void Semra_Analyzer::InitHistos(const std::map<std::string, bool>& cutmap) // de
         //my_histos.emplace( "h_relativeDiff_stopMasses_"+cutVar.first, std::make_shared<TH1D> ( ("h_relativeDiff_stopMasses_"+cutVar.first).c_str(), ("h_relativeDiff_stopMasses_"+cutVar.first).c_str(), 500, -1500, 1500) );
 
         // stop1VSstop2 Mass, Eta, Phi, Pt       
+        // pt rank
         //my_2d_histos.emplace( "h_Mass_stop1vsstop2_PtRank_"+cutVar.first, std::make_shared<TH2D>( ("h_Mass_stop1vsstop2_PtRank_"+cutVar.first).c_str(), ("h_Mass_stop1vsstop2_PtRank_"+cutVar.first).c_str(), 500, 0, 1500, 500, 0, 1500 ) );
         //my_2d_histos.emplace( "h_Eta_stop1vsstop2_PtRank_"+cutVar.first, std::make_shared<TH2D>( ("h_Eta_stop1vsstop2_PtRank_"+cutVar.first).c_str(), ("h_Eta_stop1vsstop2_PtRank_"+cutVar.first).c_str(), 100, -6, 6, 100, -6, 6 ) );
         //my_2d_histos.emplace( "h_Phi_stop1vsstop2_PtRank_"+cutVar.first, std::make_shared<TH2D>( ("h_Phi_stop1vsstop2_PtRank_"+cutVar.first).c_str(), ("h_Phi_stop1vsstop2_PtRank_"+cutVar.first).c_str(), 80, -4, 4, 80, -4, 4 ) );
         //my_2d_histos.emplace( "h_Pt_stop1vsstop2_PtRank_"+cutVar.first, std::make_shared<TH2D>( ("h_Pt_stop1vsstop2_PtRank_"+cutVar.first).c_str(), ("h_Pt_stop1vsstop2_PtRank_"+cutVar.first).c_str(), 100, 0, 1000, 100, 0, 1000) );
+        // mass rank
         //my_2d_histos.emplace( "h_Mass_stop1vsstop2_MassRank_"+cutVar.first, std::make_shared<TH2D>( ("h_Mass_stop1vsstop2_MassRank_"+cutVar.first).c_str(), ("h_Mass_stop1vsstop2_MassRank_"+cutVar.first).c_str(), 500, 0, 1500, 500, 0, 1500 ) );
         //my_2d_histos.emplace( "h_Eta_stop1vsstop2_MassRank_"+cutVar.first, std::make_shared<TH2D>( ("h_Eta_stop1vsstop2_MassRank_"+cutVar.first).c_str(), ("h_Eta_stop1vsstop2_MassRank_"+cutVar.first).c_str(), 100, -6, 6, 100, -6, 6 ) );
         //my_2d_histos.emplace( "h_Phi_stop1vsstop2_MassRank_"+cutVar.first, std::make_shared<TH2D>( ("h_Phi_stop1vsstop2_MassRank_"+cutVar.first).c_str(), ("h_Phi_stop1vsstop2_MassRank_"+cutVar.first).c_str(), 80, -4, 4, 80, -4, 4 ) );
         //my_2d_histos.emplace( "h_Pt_stop1vsstop2_MassRank_"+cutVar.first, std::make_shared<TH2D>( ("h_Pt_stop1vsstop2_MassRank_"+cutVar.first).c_str(), ("h_Pt_stop1vsstop2_MassRank_"+cutVar.first).c_str(), 100, 0, 1000, 100, 0, 1000) );
+        // scalarPt rank
         //my_2d_histos.emplace( "h_Mass_stop1vsstop2_ScalarPtRank_"+cutVar.first, std::make_shared<TH2D>( ("h_Mass_stop1vsstop2_ScalarPtRank_"+cutVar.first).c_str(), ("h_Mass_stop1vsstop2_ScalarPtRank_"+cutVar.first).c_str(), 500, 0, 1500, 500, 0, 1500 ) );    
         //my_2d_histos.emplace( "h_Eta_stop1vsstop2_ScalarPtRank_"+cutVar.first, std::make_shared<TH2D>( ("h_Eta_stop1vsstop2_ScalarPtRank_"+cutVar.first).c_str(), ("h_Eta_stop1vsstop2_ScalarPtRank_"+cutVar.first).c_str(), 100, -6, 6, 100, -6, 6 ) );
         //my_2d_histos.emplace( "h_Phi_stop1vsstop2_ScalarPtRank_"+cutVar.first, std::make_shared<TH2D>( ("h_Phi_stop1vsstop2_ScalarPtRank_"+cutVar.first).c_str(), ("h_Phi_stop1vsstop2_ScalarPtRank_"+cutVar.first).c_str(), 80, -4, 4, 80, -4, 4 ) );
@@ -121,9 +131,9 @@ void Semra_Analyzer::InitHistos(const std::map<std::string, bool>& cutmap) // de
         //my_2d_histos.emplace( "h_Mass_NJetsVSstop2_MassRank_"+cutVar.first, std::make_shared<TH2D> ( ("h_Mass_NJetsVSstop2_MassRank_"+cutVar.first).c_str(), ("h_Mass_NJetsVSstop2_MassRank_"+cutVar.first).c_str(), 20, 0, 20, 500, 0, 1500 ) );       
         //my_2d_histos.emplace( "h_Mass_NJetsVSstop1_ScalarPtRank_"+cutVar.first, std::make_shared<TH2D> ( ("h_Mass_NJetsVSstop1_ScalarPtRank_"+cutVar.first).c_str(), ("h_Mass_NJetsVSstop1_ScalarPtRank_"+cutVar.first).c_str(), 20, 0, 20, 500, 0, 1500 ) );
         //my_2d_histos.emplace( "h_Mass_NJetsVSstop2_ScalarPtRank_"+cutVar.first, std::make_shared<TH2D> ( ("h_Mass_NJetsVSstop2_ScalarPtRank_"+cutVar.first).c_str(), ("h_Mass_NJetsVSstop2_ScalarPtRank_"+cutVar.first).c_str(), 20, 0, 20, 500, 0, 1500 ) );
-        //my_2d_histos.emplace( "h_stopMasses_diffVSavg_"+cutVar.first, std::make_shared<TH2D>( ("h_stopMasses_diffVSavg_"+cutVar.first).c_str(), ("h_stopMasses_diffVSavg"+cutVar.first).c_str(), 150, -1500, 1500, 150, 0, 1500 ) );
+        //my_2d_histos.emplace( "h_stopMasses_diffVSavg_"+cutVar.first, std::make_shared<TH2D>( ("h_stopMasses_diffVSavg_"+cutVar.first).c_str(), ( "h_stopMasses_diffVSavg"+cutVar.first).c_str(), 150, -1500, 1500, 150, 0, 1500 ) );
 
-        // stop All Pt combinations 
+        // stop TaggedTop Pt combinations 
         //my_2d_histos.emplace( "h_ScalarPt_stop1vsstop2_ScalarPtRank_"+cutVar.first, std::make_shared<TH2D>( ("h_ScalarPt_stop1vsstop2_ScalarPtRank_"+cutVar.first).c_str(), ("h_ScalarPt_stop1vsstop2_ScalarPtRank_"+cutVar.first).c_str(), 100, 0, 1000, 100, 0, 1000) );
         //my_2d_histos.emplace( "h_Pt1_PtRankVsScalarPtRank_"+cutVar.first, std::make_shared<TH2D>( ("h_Pt1_PtRankVsScalarPtRank_"+cutVar.first).c_str(), ("h_Pt1_PtRankVsScalarPtRank_"+cutVar.first).c_str(), 100, 0, 1000, 100, 0, 1000) );
         //my_2d_histos.emplace( "h_Pt2_PtRankVsScalarPtRank_"+cutVar.first, std::make_shared<TH2D>( ("h_Pt2_PtRankVsScalarPtRank_"+cutVar.first).c_str(), ("h_Pt2_PtRankVsScalarPtRank_"+cutVar.first).c_str(), 100, 0, 1000, 100, 0, 1000) );
@@ -131,10 +141,13 @@ void Semra_Analyzer::InitHistos(const std::map<std::string, bool>& cutmap) // de
         //my_2d_histos.emplace( "h_Pt2_PtRankVsScalarPt2_ScalarPtRank"+cutVar.first, std::make_shared<TH2D>( ("h_Pt2_PtRankVsScalarPt2_ScalarPtRank_"+cutVar.first).c_str(), ("h_Pt2_PtRankVsScalarPt2_ScalarPtRank_"+cutVar.first).c_str(), 100, 0, 1000, 100, 0, 1000) );
 
         // stops MassVsPt
+        // pt rank
         //my_2d_histos.emplace( "h_stop1_MassVsPt_PtRank_"+cutVar.first, std::make_shared<TH2D>( ("h_stop1_MassVsPt_PtRank_"+cutVar.first).c_str(), ("h_stop1_MassVsPt_PtRank_"+cutVar.first).c_str(), 500, 0, 1500, 100, 0, 1000 ) );
         //my_2d_histos.emplace( "h_stop2_MassVsPt_PtRank_"+cutVar.first, std::make_shared<TH2D>( ("h_stop2_MassVsPt_PtRank_"+cutVar.first).c_str(), ("h_stop2_MassVsPt_PtRank_"+cutVar.first).c_str(), 500, 0, 1500, 100, 0, 1000 ) );
+        // mask rank
         //my_2d_histos.emplace( "h_stop1_MassVsPt_MassRank_"+cutVar.first, std::make_shared<TH2D>( ("h_stop1_MassVsPt_MassRank_"+cutVar.first).c_str(), ("h_stop1_MassVsPt_MassRank_"+cutVar.first).c_str(), 500, 0, 1500, 100, 0, 1000 ) );
         //my_2d_histos.emplace( "h_stop2_MassVsPt_MassRank_"+cutVar.first, std::make_shared<TH2D>( ("h_stop2_MassVsPt_MassRank_"+cutVar.first).c_str(), ("h_stop2_MassVsPt_MassRank_"+cutVar.first).c_str(), 500, 0, 1500, 100, 0, 1000 ) );
+        // scalarPt rank
         //my_2d_histos.emplace( "h_stop1_MassVsPt_ScalarPtRank_"+cutVar.first, std::make_shared<TH2D>( ("h_stop1_MassVsPt_ScalarPtRank_"+cutVar.first).c_str(), ("h_stop1_MassVsPt_ScalarPtRank_"+cutVar.first).c_str(), 500, 0, 1500, 100, 0, 1000 ) );
         //my_2d_histos.emplace( "h_stop2_MassVsPt_ScalarPtRank_"+cutVar.first, std::make_shared<TH2D>( ("h_stop2_MassVsPt_ScalarPtRank_"+cutVar.first).c_str(), ("h_stop2_MassVsPt_ScalarPtRank_"+cutVar.first).c_str(), 500, 0, 1500, 100, 0, 1000 ) );
         //my_2d_histos.emplace( "h_stop1_MassVsScalarPt_ScalarPtRank_"+cutVar.first, std::make_shared<TH2D>( ("h_stop1_MassVsScalarPt_ScalarPtRank_"+cutVar.first).c_str(), ("h_stop1_MassVsScalarPt_ScalarPtRank_"+cutVar.first).c_str(), 500, 0, 1500, 100, 0, 1000 ) );
@@ -153,21 +166,21 @@ void Semra_Analyzer::InitHistos(const std::map<std::string, bool>& cutmap) // de
         // -- stop gen level
         // --------------------
         // Reco
-        my_histos.emplace( "h_StopRecoMT2_"+cutVar.first, std::make_shared<TH1D> ( ("h_StopRecoMT2_"+cutVar.first).c_str(), ("h_StopRecoMT2_"+cutVar.first).c_str(), 500, 0, 1500) ); 
-        my_histos.emplace( "h_Stop1RecoMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Stop1RecoMass_"+cutVar.first).c_str(), ("h_Stop1RecoMass_"+cutVar.first).c_str(), 500, 0, 1500) );
-        my_histos.emplace( "h_Stop2RecoMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Stop2RecoMass_"+cutVar.first).c_str(), ("h_Stop2RecoMass_"+cutVar.first).c_str(), 500, 0, 1500) );
-        my_histos.emplace( "h_Nlino1RecoMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Nlino1RecoMass_"+cutVar.first).c_str(), ("h_Nlino1RecoMass_"+cutVar.first).c_str(), 500, 0, 1500) );
-        my_histos.emplace( "h_Nlino2RecoMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Nlino2RecoMass_"+cutVar.first).c_str(), ("h_Nlino2RecoMass_"+cutVar.first).c_str(), 500, 0, 1500) );
-        my_histos.emplace( "h_Single1RecoMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Single1RecoMass_"+cutVar.first).c_str(), ("h_Single1RecoMass_"+cutVar.first).c_str(), 500, 0, 1500) );
-        my_histos.emplace( "h_Single2RecoMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Single2RecoMass_"+cutVar.first).c_str(), ("h_Single2RecoMass_"+cutVar.first).c_str(), 500, 0, 1500) );
+        //my_histos.emplace( "h_StopRecoMT2_"+cutVar.first, std::make_shared<TH1D> ( ("h_StopRecoMT2_"+cutVar.first).c_str(), ("h_StopRecoMT2_"+cutVar.first).c_str(), 500, 0, 1500) ); 
+        //my_histos.emplace( "h_Stop1RecoMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Stop1RecoMass_"+cutVar.first).c_str(), ("h_Stop1RecoMass_"+cutVar.first).c_str(), 500, 0, 1500) );
+        //my_histos.emplace( "h_Stop2RecoMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Stop2RecoMass_"+cutVar.first).c_str(), ("h_Stop2RecoMass_"+cutVar.first).c_str(), 500, 0, 1500) );
+        //my_histos.emplace( "h_Nlino1RecoMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Nlino1RecoMass_"+cutVar.first).c_str(), ("h_Nlino1RecoMass_"+cutVar.first).c_str(), 500, 0, 1500) );
+        //my_histos.emplace( "h_Nlino2RecoMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Nlino2RecoMass_"+cutVar.first).c_str(), ("h_Nlino2RecoMass_"+cutVar.first).c_str(), 500, 0, 1500) );
+        //my_histos.emplace( "h_Single1RecoMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Single1RecoMass_"+cutVar.first).c_str(), ("h_Single1RecoMass_"+cutVar.first).c_str(), 500, 0, 1500) );
+        //my_histos.emplace( "h_Single2RecoMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Single2RecoMass_"+cutVar.first).c_str(), ("h_Single2RecoMass_"+cutVar.first).c_str(), 500, 0, 1500) );
         // Gen
-        my_histos.emplace( "h_StopGenMT2_"+cutVar.first, std::make_shared<TH1D> ( ("h_StopGenMT2_"+cutVar.first).c_str(), ("h_StopGenMT2_"+cutVar.first).c_str(), 500, 0, 1500) );
-        my_histos.emplace( "h_Stop1GenMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Stop1GenMass_"+cutVar.first).c_str(), ("h_Stop1GenMass_"+cutVar.first).c_str(), 500, 0, 1500) );
-        my_histos.emplace( "h_Stop2GenMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Stop2GenMass_"+cutVar.first).c_str(), ("h_Stop2GenMass_"+cutVar.first).c_str(), 500, 0, 1500) );
-        my_histos.emplace( "h_Nlino1GenMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Nlino1GenMass_"+cutVar.first).c_str(), ("h_Nlino1GenMass_"+cutVar.first).c_str(), 500, 0, 1500) );
-        my_histos.emplace( "h_Nlino2GenMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Nlino2GenMass_"+cutVar.first).c_str(), ("h_Nlino2GenMass_"+cutVar.first).c_str(), 500, 0, 1500) );
-        my_histos.emplace( "h_Single1GenMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Single1GenMass_"+cutVar.first).c_str(), ("h_Single1GenMass_"+cutVar.first).c_str(), 500, 0, 1500) );
-        my_histos.emplace( "h_Single2GenMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Single2GenMass_"+cutVar.first).c_str(), ("h_Single2GenMass_"+cutVar.first).c_str(), 500, 0, 1500) );
+        //my_histos.emplace( "h_StopGenMT2_"+cutVar.first, std::make_shared<TH1D> ( ("h_StopGenMT2_"+cutVar.first).c_str(), ("h_StopGenMT2_"+cutVar.first).c_str(), 500, 0, 1500) );
+        //my_histos.emplace( "h_Stop1GenMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Stop1GenMass_"+cutVar.first).c_str(), ("h_Stop1GenMass_"+cutVar.first).c_str(), 500, 0, 1500) );
+        //my_histos.emplace( "h_Stop2GenMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Stop2GenMass_"+cutVar.first).c_str(), ("h_Stop2GenMass_"+cutVar.first).c_str(), 500, 0, 1500) );
+        //my_histos.emplace( "h_Nlino1GenMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Nlino1GenMass_"+cutVar.first).c_str(), ("h_Nlino1GenMass_"+cutVar.first).c_str(), 500, 0, 1500) );
+        //my_histos.emplace( "h_Nlino2GenMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Nlino2GenMass_"+cutVar.first).c_str(), ("h_Nlino2GenMass_"+cutVar.first).c_str(), 500, 0, 1500) );
+        //my_histos.emplace( "h_Single1GenMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Single1GenMass_"+cutVar.first).c_str(), ("h_Single1GenMass_"+cutVar.first).c_str(), 500, 0, 1500) );
+        //my_histos.emplace( "h_Single2GenMass_"+cutVar.first, std::make_shared<TH1D> ( ("h_Single2GenMass_"+cutVar.first).c_str(), ("h_Single2GenMass_"+cutVar.first).c_str(), 500, 0, 1500) );
 
     }
 
@@ -191,17 +204,20 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
         if( maxevents != -1 && tr.getEvtNum() >= maxevents ) break;
         if( tr.getEvtNum() & (10000 == 0) ) printf( " Event %i\n", tr.getEvtNum() );
 
-        const auto& runtype          = tr.getVar<std::string>("runtype");     
-        const auto& JetID            = tr.getVar<bool>("JetID");
-        //const auto& Jets             = tr.getVec<TLorentzVector>("Jets");
-        const auto& NGoodLeptons     = tr.getVar<int>("NGoodLeptons");
-        const auto& MET              = tr.getVar<double>("MET");
-        //const auto& GoodBJets_pt45   = tr.getVec<bool>("GoodBJets_pt45");
-        const auto& HT_trigger_pt45  = tr.getVar<double>("HT_trigger_pt45");
-        const auto& NGoodJets_pt45   = tr.getVar<int>("NGoodJets_pt45");
-        const auto& NGoodBJets_pt45  = tr.getVar<int>("NGoodBJets_pt45");
-        const auto& passMadHT        = tr.getVar<bool>("passMadHT");
-        const auto& dR_bjets         = tr.getVar<double>("dR_bjets");               
+        const auto& runtype         = tr.getVar<std::string>("runtype");     
+        const auto& JetID           = tr.getVar<bool>("JetID");
+        const auto& Jets            = tr.getVec<TLorentzVector>("Jets");
+        const auto& NGoodLeptons    = tr.getVar<int>("NGoodLeptons");
+        const auto& MET             = tr.getVar<double>("MET");
+        const auto& GoodJets_pt45   = tr.getVec<bool>("GoodJets_pt45");
+        const auto& GoodBJets_pt45  = tr.getVec<bool>("GoodBJets_pt45");
+        const auto& HT_trigger_pt45 = tr.getVar<double>("HT_trigger_pt45");
+        const auto& NGoodJets_pt45  = tr.getVar<int>("NGoodJets_pt45");
+        const auto& NGoodBJets_pt45 = tr.getVar<int>("NGoodBJets_pt45");
+        //const auto& deepESM_val     = tr.getVar<double>("deepESM_val");
+        const auto& dR_bjets        = tr.getVar<double>("dR_bjets");               
+        const auto& dR_top1_top2    = tr.getVar<double>("dR_top1_top2");
+        const auto& topsLV          = tr.getVec<TLorentzVector>("topsLV");
  
         // ------------------------------
         // -- Define Top Tag variables
@@ -210,15 +226,19 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
         const auto& ntops_1jet     = tr.getVar<int>("ntops_1jet");
         const auto& ntops_2jet     = tr.getVar<int>("ntops_2jet");
         const auto& ntops_3jet     = tr.getVar<int>("ntops_3jet");
-        //const auto& topsMass       = tr.getVec<double>("topsMass");
-        //const auto& topsEta        = tr.getVec<double>("topsEta");
-        //const auto& topsPhi        = tr.getVec<double>("topsPhi");  
-        //const auto& topsPt         = tr.getVec<double>("topsPt");
-        //const auto& bestTopMass    = tr.getVar<double>("bestTopMass");
-        //const auto& bestTopEta     = tr.getVar<double>("bestTopEta");
-        //const auto& bestTopPt      = tr.getVar<double>("bestTopPt");
-        //const auto& dR_top1_top2   = tr.getVar<double>("dR_top1_top2");
-        //const auto& topsLV         = tr.getVec<TLorentzVector>("topsLV");
+        const auto& topsMass       = tr.getVec<double>("topsMass");
+        const auto& topsEta        = tr.getVec<double>("topsEta");
+        const auto& topsPhi        = tr.getVec<double>("topsPhi");  
+        const auto& topsPt         = tr.getVec<double>("topsPt");
+        const auto& resolvedMass   = tr.getVar<double>("resolvedMass");
+        const auto& resolvedEta    = tr.getVar<double>("resolvedEta");
+        const auto& resolvedPhi    = tr.getVar<double>("resolvedPhi");
+        const auto& resolvedPt     = tr.getVar<double>("resolvedPt");
+        const auto& bestTopMass    = tr.getVar<double>("bestTopMass");
+        const auto& bestTopEta     = tr.getVar<double>("bestTopEta");
+        const auto& bestTopPt      = tr.getVar<double>("bestTopPt");
+       
+        const auto& passMadHT      = tr.getVar<bool>("passMadHT");
         const auto& passBaseline0l = tr.getVar<bool>("passBaseline0l_Good");
         const auto& passMETFilters = tr.getVar<bool>("passMETFilters");
         const bool pass_general    = JetID && passMETFilters && passMadHT;
@@ -235,42 +255,38 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
         // ------------------------------------------
         // -- MT2 or Stealth hemispheres variables
         // ------------------------------------------
-        //const auto& stop1_PtRank               = tr.getVar<TLorentzVector>("stop1_PtRank_TopSeed");
-        //const auto& stop2_PtRank               = tr.getVar<TLorentzVector>("stop2_PtRank_TopSeed");
-        //const auto& stop1_MassRank             = tr.getVar<TLorentzVector>("stop1_MassRank_TopSeed");
-        //const auto& stop2_MassRank             = tr.getVar<TLorentzVector>("stop2_MassRank_TopSeed");
-        //const auto& stop1_ScalarPtRank         = tr.getVar<TLorentzVector>("stop1_ScalarPtRank_TopSeed");
-        //const auto& stop2_ScalarPtRank         = tr.getVar<TLorentzVector>("stop2_ScalarPtRank_TopSeed");
-        //const auto& stop1ScalarPt_ScalarPtRank = tr.getVar<double>("stop1ScalarPt_ScalarPtRank_TopSeed");
-        //const auto& stop2ScalarPt_ScalarPtRank = tr.getVar<double>("stop2ScalarPt_ScalarPtRank_TopSeed");
-        //const auto& MT2                        = tr.getVar<double>("MT2_TopSeed"); 
-        //const auto& dR_stop1stop2              = tr.getVar<double>("dR_stop1stop2_TopSeed");
-        //const auto& dPhi_stop1stop2            = tr.getVar<double>("dPhi_stop1stop2_TopSeed");
-        //const auto& difference_stopMasses      = tr.getVar<double>("difference_stopMasses_TopSeed");
-        //const auto& average_stopMasses         = tr.getVar<double>("average_stopMasses_TopSeed");
-        //const auto& relativeDiff_stopMasses    = tr.getVar<double>("relativeDiff_stopMasses_TopSeed");
-        //const auto& resolvedMass               = tr.getVar<double>("resolvedMass");
-        //const auto& resolvedEta                = tr.getVar<double>("resolvedEta");
-        //const auto& resolvedPhi                = tr.getVar<double>("resolvedPhi");
-        //const auto& resolvedPt                 = tr.getVar<double>("resolvedPt");
+        //const auto& stop1_PtRank               = tr.getVar<TLorentzVector>("stop1_PtRank_TaggedTop");
+        //const auto& stop2_PtRank               = tr.getVar<TLorentzVector>("stop2_PtRank_TaggedTop");
+        //const auto& stop1_MassRank             = tr.getVar<TLorentzVector>("stop1_MassRank_TaggedTop");
+        //const auto& stop2_MassRank             = tr.getVar<TLorentzVector>("stop2_MassRank_TaggedTop");
+        //const auto& stop1_ScalarPtRank         = tr.getVar<TLorentzVector>("stop1_ScalarPtRank_TaggedTop");
+        //const auto& stop2_ScalarPtRank         = tr.getVar<TLorentzVector>("stop2_ScalarPtRank_TaggedTop");
+        //const auto& stop1ScalarPt_ScalarPtRank = tr.getVar<double>("stop1ScalarPt_ScalarPtRank_TaggedTop");
+        //const auto& stop2ScalarPt_ScalarPtRank = tr.getVar<double>("stop2ScalarPt_ScalarPtRank_TaggedTop");
+        //const auto& MT2                        = tr.getVar<double>("MT2_TaggedTop"); 
+        //const auto& dR_stop1stop2              = tr.getVar<double>("dR_stop1stop2_TaggedTop");
+        //const auto& dPhi_stop1stop2            = tr.getVar<double>("dPhi_stop1stop2_TaggedTop");
+        //const auto& difference_stopMasses      = tr.getVar<double>("difference_stopMasses_TaggedTop");
+        //const auto& average_stopMasses         = tr.getVar<double>("average_stopMasses_TaggedTop");
+        //const auto& relativeDiff_stopMasses    = tr.getVar<double>("relativeDiff_stopMasses_TaggedTop");
 
         // --------------------
         // -- stop gen level
         // --------------------
-        const auto& StopRecoMT2     = tr.getVar<double>("GM_StopMT2"); // Reco Sum List
-        const auto& Stop1RecoMass   = tr.getVar<double>("GM_Stop1Mass"); // Reco 
-        const auto& Stop2RecoMass   = tr.getVar<double>("GM_Stop2Mass"); // Reco 
-        const auto& Nlino1RecoMass  = tr.getVar<double>("GM_Nlino1Mass"); // Reco 
-        const auto& Nlino2RecoMass  = tr.getVar<double>("GM_Nlino2Mass"); // Reco
-        const auto& Single1RecoMass = tr.getVar<double>("GM_Single1Mass"); // Reco 
-        const auto& Single2RecoMass = tr.getVar<double>("GM_Single2Mass"); // Reco
-        const auto& StopGenMT2      = tr.getVar<double>("GM_StopGenMT2"); // Gen Sum List
-        const auto& Stop1GenMass    = tr.getVar<double>("GM_Stop1GenMass"); // Gen 
-        const auto& Stop2GenMass    = tr.getVar<double>("GM_Stop2GenMass"); // Gen 
-        const auto& Nlino1GenMass   = tr.getVar<double>("GM_Nlino1GenMass"); // Gen
-        const auto& Nlino2GenMass   = tr.getVar<double>("GM_Nlino2GenMass"); // Gen
-        const auto& Single1GenMass  = tr.getVar<double>("GM_Single1GenMass"); // Gen 
-        const auto& Single2GenMass  = tr.getVar<double>("GM_Single2GenMass"); // Gen
+        //const auto& StopRecoMT2     = tr.getVar<double>("GM_StopMT2"); // Reco Sum List
+        //const auto& Stop1RecoMass   = tr.getVar<double>("GM_Stop1Mass"); // Reco 
+        //const auto& Stop2RecoMass   = tr.getVar<double>("GM_Stop2Mass"); // Reco 
+        //const auto& Nlino1RecoMass  = tr.getVar<double>("GM_Nlino1Mass"); // Reco 
+        //const auto& Nlino2RecoMass  = tr.getVar<double>("GM_Nlino2Mass"); // Reco
+        //const auto& Single1RecoMass = tr.getVar<double>("GM_Single1Mass"); // Reco 
+        //const auto& Single2RecoMass = tr.getVar<double>("GM_Single2Mass"); // Reco
+        //const auto& StopGenMT2      = tr.getVar<double>("GM_StopGenMT2"); // Gen Sum List
+        //const auto& Stop1GenMass    = tr.getVar<double>("GM_Stop1GenMass"); // Gen 
+        //const auto& Stop2GenMass    = tr.getVar<double>("GM_Stop2GenMass"); // Gen 
+        //const auto& Nlino1GenMass   = tr.getVar<double>("GM_Nlino1GenMass"); // Gen
+        //const auto& Nlino2GenMass   = tr.getVar<double>("GM_Nlino2GenMass"); // Gen
+        //const auto& Single1GenMass  = tr.getVar<double>("GM_Single1GenMass"); // Gen 
+        //const auto& Single2GenMass  = tr.getVar<double>("GM_Single2GenMass"); // Gen
 
         // -------------------
         // -- Define weight
@@ -294,21 +310,21 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
             weight *= eventweight*bTagScaleFactor*prefiringScaleFactor*puScaleFactor;
         }
 
-        //// ---------------------------------------------
-        //// -- Calculate DeltaR between tops and bjets
-        //// ---------------------------------------------
-        //std::vector<TLorentzVector> bjets;
-        //for(unsigned int ijet = 0; ijet < Jets.size(); ijet++) {
-        //    if(!GoodBJets_pt45[ijet]) continue;
-        //    bjets.push_back(Jets.at(ijet));        
-        //}
-        //std::vector<double> dR_top_bjet;
-        //for (unsigned int t = 0; t < topsLV.size(); t++) {
-        //    for (unsigned int b = 0; b < bjets.size(); b++) {
-        //        double deltaR = topsLV.at(t).DeltaR(bjets.at(b));
-        //        dR_top_bjet.push_back(deltaR);
-        //    }
-        //}
+        // ---------------------------------------------
+        // -- Calculate DeltaR between tops and bjets
+        // ---------------------------------------------
+        std::vector<TLorentzVector> bjets;
+        for(unsigned int ijet = 0; ijet < Jets.size(); ijet++) {
+            if(!GoodBJets_pt45[ijet]) continue;
+            bjets.push_back(Jets.at(ijet));        
+        }
+        std::vector<double> dR_top_bjet;
+        for (unsigned int t = 0; t < topsLV.size(); t++) {
+            for (unsigned int b = 0; b < bjets.size(); b++) {
+                double deltaR = topsLV.at(t).DeltaR(bjets.at(b));
+                dR_top_bjet.push_back(deltaR);
+            }
+        }
   
         // -----------------------------------
         // -- get MT2 hemispheres variables
@@ -352,24 +368,24 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
         // -------------------------------------------------
         const std::map<std::string, bool>& cutmap
         {
-            {"",                                       true                                                            },
-            {"0l",                                     pass_general && pass_0l                                         },
-            {"0l_HT500",                               pass_general && pass_0l && pass_HT500                           },           
-            {"0l_HT500_ge2b",                          pass_general && pass_0l && pass_HT500 && pass_ge2b              },     
-            {"0l_HT500_ge2b_ge6j",                     pass_general && pass_0l && pass_HT500 && pass_ge2b && pass_ge6j },
+            //{"",                                       true                                                            },
+            //{"0l",                                     pass_general && pass_0l                                         },
+            //{"0l_HT500",                               pass_general && pass_0l && pass_HT500                           },           
+            //{"0l_HT500_ge2b",                          pass_general && pass_0l && pass_HT500 && pass_ge2b              },     
+            //{"0l_HT500_ge2b_ge6j",                     pass_general && pass_0l && pass_HT500 && pass_ge2b && pass_ge6j },
             
             // >= 2 tops
-            {"0l_HT500_ge2b_ge6j_ge2t",                passBaseline0l && pass_ge2t     },
-            {"0l_HT500_ge2b_ge6j_ge2t1j",              passBaseline0l && pass_ge2t1j   },
-            {"0l_HT500_ge2b_ge6j_ge2t3j",              passBaseline0l && pass_ge2t3j   },
-            {"0l_HT500_ge2b_ge6j_ge2t1j3j",            passBaseline0l && pass_ge2t1j3j }, 
+            //{"0l_HT500_ge2b_ge6j_ge2t",                passBaseline0l && pass_ge2t     },
+            //{"0l_HT500_ge2b_ge6j_ge2t1j",              passBaseline0l && pass_ge2t1j   },
+            //{"0l_HT500_ge2b_ge6j_ge2t3j",              passBaseline0l && pass_ge2t3j   },
+            //{"0l_HT500_ge2b_ge6j_ge2t1j3j",            passBaseline0l && pass_ge2t1j3j }, 
             
             // dR_bjets >= 1
             {"0l_HT500_ge2b_ge6j_ge2t_ge1dRbjets",     passBaseline0l && pass_ge2t && pass_ge1dRbjets     },
             {"0l_HT500_ge2b_ge6j_ge2t1j_ge1dRbjets",   passBaseline0l && pass_ge2t1j && pass_ge1dRbjets   },
             {"0l_HT500_ge2b_ge6j_ge2t3j_ge1dRbjets",   passBaseline0l && pass_ge2t3j && pass_ge1dRbjets   },
             {"0l_HT500_ge2b_ge6j_ge2t1j3j_ge1dRbjets", passBaseline0l && pass_ge2t1j3j && pass_ge1dRbjets },
-        
+       
             // pt Rank stopMasses cuts
             //{"baseline_0l_stopMassesg200_PtRank",          passBaseline0l && pass_ge2t && pass_ge1dRbjets && stop1Mass_PtRank > 200 && stop2Mass_PtRank > 200     },
             //{"baseline_0l_ge2t1j_stopMassesg200_PtRank",   passBaseline0l && pass_ge2t1j && pass_ge1dRbjets && stop1Mass_PtRank > 200 && stop2Mass_PtRank > 200   },
@@ -427,15 +443,15 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
     // --------------------------------     
     for (const auto& cutVar: cutmap) {        
         if (cutVar.second) {
-            //my_histos["h_ntops_"+cutVar.first]->Fill( ntops, weight );
-            //my_histos["h_njets_"+cutVar.first]->Fill( NGoodJets_pt45, weight );
-            //my_histos["h_nbjets_"+cutVar.first]->Fill( NGoodBJets_pt45, weight );
-            //my_histos["h_ht_"+cutVar.first]->Fill( HT_trigger_pt45, weight );
-            //my_histos["h_met_"+cutVar.first]->Fill( MET, weight );
-            //
-            //// -----------------------------
-            //// -- jets & bjets mass & pT
-            //// -----------------------------
+            my_histos["h_ntops_"+cutVar.first]->Fill( ntops, weight );
+            my_histos["h_njets_"+cutVar.first]->Fill( NGoodJets_pt45, weight );
+            my_histos["h_nbjets_"+cutVar.first]->Fill( NGoodBJets_pt45, weight );
+            my_histos["h_ht_"+cutVar.first]->Fill( HT_trigger_pt45, weight );
+            my_histos["h_met_"+cutVar.first]->Fill( MET, weight );
+            
+            // -----------------------------
+            // -- jets & bjets mass & pT
+            // -----------------------------
             //for(int ijet = 0; ijet < Jets.size(); ijet++) {
             //    if(!GoodJets_pt45[ijet]) continue;
             //    my_histos["h_jetsPt_"+cutVar.first]->Fill(Jets.at(ijet).Pt(), weight);
@@ -450,41 +466,41 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
             // --------------------------------------
             // -- get top jets' Mass, Eta, Phi, Pt 
             // --------------------------------------
-            //for (unsigned int itops = 0; itops < topsMass.size(); itops++) 
-            //{
-            //    my_histos["h_topsMass_"+cutVar.first]->Fill( topsMass.at(itops), weight );
-            //}
+            for (unsigned int itops = 0; itops < topsMass.size(); itops++) 
+            {
+                my_histos["h_topsMass_"+cutVar.first]->Fill( topsMass.at(itops), weight );
+            }
         
-            //for (unsigned int itops = 0; itops < topsEta.size(); itops++) {
-            //    my_histos["h_topsEta_"+cutVar.first]->Fill( topsEta.at(itops), weight );
-            //}
+            for (unsigned int itops = 0; itops < topsEta.size(); itops++) {
+                my_histos["h_topsEta_"+cutVar.first]->Fill( topsEta.at(itops), weight );
+            }
        
-            //for (unsigned int itops = 0; itops < topsPhi.size(); itops++) {
-            //    my_histos["h_topsPhi_"+cutVar.first]->Fill( topsPhi.at(itops), weight );
-            //}
+            for (unsigned int itops = 0; itops < topsPhi.size(); itops++) {
+                my_histos["h_topsPhi_"+cutVar.first]->Fill( topsPhi.at(itops), weight );
+            }
  
-            //for (unsigned int itops = 0; itops < topsPt.size(); itops++) {
-            //    my_histos["h_topsPt_"+cutVar.first]->Fill( topsPt.at(itops), weight );
-            //}      
+            for (unsigned int itops = 0; itops < topsPt.size(); itops++) {
+                my_histos["h_topsPt_"+cutVar.first]->Fill( topsPt.at(itops), weight );
+            }      
 
             // get the resolved jets' Mass, Eta, Phi, Pt
-            //my_histos["h_resolvedMass_"+cutVar.first]->Fill( resolvedMass, weight );
-            //my_histos["h_resolvedEta_"+cutVar.first]->Fill( resolvedEta, weight );
-            //my_histos["h_resolvedPhi_"+cutVar.first]->Fill( resolvedPhi, weight );
-            //my_histos["h_resolvedPt_"+cutVar.first]->Fill( resolvedPt, weight ); 
+            my_histos["h_resolvedMass_"+cutVar.first]->Fill( resolvedMass, weight );
+            my_histos["h_resolvedEta_"+cutVar.first]->Fill( resolvedEta, weight );
+            my_histos["h_resolvedPhi_"+cutVar.first]->Fill( resolvedPhi, weight );
+            my_histos["h_resolvedPt_"+cutVar.first]->Fill( resolvedPt, weight ); 
      
-            //my_histos["h_bestTopMass_"+cutVar.first]->Fill( bestTopMass, weight );
-            //my_histos["h_bestTopEta_"+cutVar.first]->Fill( bestTopEta, weight );
-            //my_histos["h_bestTopPt_"+cutVar.first]->Fill( bestTopPt, weight );
-            //my_histos["h_dR_bjet1_bjet2_"+cutVar.first]->Fill( dR_bjets, weight );
-            //my_histos["h_dR_top1_top2_"+cutVar.first]->Fill( dR_top1_top2, weight );
+            my_histos["h_bestTopMass_"+cutVar.first]->Fill( bestTopMass, weight );
+            my_histos["h_bestTopEta_"+cutVar.first]->Fill( bestTopEta, weight );
+            my_histos["h_bestTopPt_"+cutVar.first]->Fill( bestTopPt, weight );
+            my_histos["h_dR_bjets_"+cutVar.first]->Fill( dR_bjets, weight );
+            my_histos["h_dR_top1_top2_"+cutVar.first]->Fill( dR_top1_top2, weight );
     
-            //// ---------------------------------
-            //// -- deltaR between top and bjet
-            //// ---------------------------------
-            //for (int idR = 0; idR < dR_top_bjet.size(); idR++) {
-            //    my_histos["h_dR_tops_bjets_"+cutVar.first]->Fill( dR_top_bjet.at(idR), weight );        
-            //}
+            // ---------------------------------
+            // -- deltaR between top and bjet
+            // ---------------------------------
+            for (unsigned int idR = 0; idR < dR_top_bjet.size(); idR++) {
+                my_histos["h_dR_tops_bjets_"+cutVar.first]->Fill( dR_top_bjet.at(idR), weight );        
+            }
          
             //my_2d_histos["h_njets_MVA_"+cutVar.first]->Fill( NGoodJets_pt45, deepESM_val, weight );
             //my_2d_histos["h_njets_MVA_"+cutVar.first]->GetXaxis()->SetTitle("N_{J}");
@@ -496,6 +512,7 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
             // --------------------------
             // -- stop MT2 hemispheres 
             // --------------------------
+            // ptRank
             //my_histos["h_stop1Mass_PtRank_"+cutVar.first]->Fill( stop1Mass_PtRank, weight );
             //my_histos["h_stop1Eta_PtRank_"+cutVar.first]->Fill( stop1Eta_PtRank, weight );
             //my_histos["h_stop1Phi_PtRank_"+cutVar.first]->Fill( stop1Phi_PtRank, weight );
@@ -504,6 +521,7 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
             //my_histos["h_stop2Eta_PtRank_"+cutVar.first]->Fill( stop2Eta_PtRank, weight );
             //my_histos["h_stop2Phi_PtRank_"+cutVar.first]->Fill( stop2Phi_PtRank, weight );
             //my_histos["h_stop2Pt_PtRank_"+cutVar.first]->Fill( stop2Pt_PtRank, weight );
+            // massRank
             //my_histos["h_stop1Mass_MassRank_"+cutVar.first]->Fill( stop1Mass_MassRank, weight );
             //my_histos["h_stop1Eta_MassRank_"+cutVar.first]->Fill( stop1Eta_MassRank, weight );
             //my_histos["h_stop1Phi_MassRank_"+cutVar.first]->Fill( stop1Phi_MassRank, weight );
@@ -512,6 +530,7 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
             //my_histos["h_stop2Eta_MassRank_"+cutVar.first]->Fill( stop2Eta_MassRank, weight );
             //my_histos["h_stop2Phi_MassRank_"+cutVar.first]->Fill( stop2Phi_MassRank, weight );
             //my_histos["h_stop2Pt_MassRank_"+cutVar.first]->Fill( stop2Pt_MassRank, weight );
+            // scalarPtRank
             //my_histos["h_stop1Mass_ScalarPtRank_"+cutVar.first]->Fill( stop1Mass_ScalarPtRank, weight );
             //my_histos["h_stop1Eta_ScalarPtRank_"+cutVar.first]->Fill( stop1Eta_ScalarPtRank, weight );
             //my_histos["h_stop1Phi_ScalarPtRank_"+cutVar.first]->Fill( stop1Phi_ScalarPtRank, weight );
@@ -521,15 +540,16 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
             //my_histos["h_stop2Phi_ScalarPtRank_"+cutVar.first]->Fill( stop2Phi_ScalarPtRank, weight );
             //my_histos["h_stop2Pt_ScalarPtRank_"+cutVar.first]->Fill( stop2Pt_ScalarPtRank, weight );
             //my_histos["h_stop1ScalarPt_ScalarPtRank_"+cutVar.first]->Fill( stop1ScalarPt_ScalarPtRank, weight );
-            //my_histos["h_stop2ScalarPt_ScalarPtRank_"+cutVar.first]->Fill( stop2ScalarPt_ScalarPtRank, weight );        
+            //my_histos["h_stop2ScalarPt_ScalarPtRank_"+cutVar.first]->Fill( stop2ScalarPt_ScalarPtRank, weight );
             //my_histos["h_MT2_"+cutVar.first]->Fill( MT2, weight );
             //my_histos["h_dR_stop1stop2_"+cutVar.first]->Fill( dR_stop1stop2, weight );
             //my_histos["h_dPhi_stop1stop2_"+cutVar.first]->Fill( dPhi_stop1stop2, weight );
             //my_histos["h_difference_stopMasses_"+cutVar.first]->Fill( difference_stopMasses, weight );
             //my_histos["h_average_stopMasses_"+cutVar.first]->Fill( average_stopMasses, weight );
             //my_histos["h_relativeDiff_stopMasses_"+cutVar.first]->Fill( relativeDiff_stopMasses, weight );
-            //// stop1VSstop2 Mass, Eta, Phi, Pt
-            //my_2d_histos["h_Mass_stop1vsstop2_PtRank_"+cutVar.first]->Fill(stop1Mass_PtRank, stop2Mass_PtRank, weight);       
+            
+            // stop1VSstop2 Mass, Eta, Phi, Pt
+            //my_2d_histos["h_Mass_stop1vsstop2_PtRank_"+cutVar.first]->Fill(stop1Mass_PtRank, stop2Mass_PtRank, weight);
             //my_2d_histos["h_Mass_stop1vsstop2_PtRank_"+cutVar.first]->GetXaxis()->SetTitle("Pt Rank M_{#tildet}_{1}");
             //my_2d_histos["h_Mass_stop1vsstop2_PtRank_"+cutVar.first]->GetYaxis()->SetTitle("Pt Rank M_{#tildet}_{2}");
             //my_2d_histos["h_Eta_stop1vsstop2_PtRank_"+cutVar.first]->Fill(stop1Eta_PtRank, stop2Eta_PtRank, weight);
@@ -565,7 +585,8 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
             //my_2d_histos["h_Pt_stop1vsstop2_ScalarPtRank_"+cutVar.first]->Fill(stop1Pt_ScalarPtRank, stop2Pt_ScalarPtRank, weight);
             //my_2d_histos["h_Pt_stop1vsstop2_ScalarPtRank_"+cutVar.first]->GetXaxis()->SetTitle("ScalarPt Rank pT_{#tildet}_{1}");
             //my_2d_histos["h_Pt_stop1vsstop2_ScalarPtRank_"+cutVar.first]->GetYaxis()->SetTitle("ScalarPt Rank pT_{#tildet}_{2}");
-            //// NJetsVSstops
+            
+            // NJetsVSstops
             //my_2d_histos["h_Mass_NJetsVSstop1_PtRank_"+cutVar.first]->Fill( NGoodJets_pt45, stop1Mass_PtRank, weight );
             //my_2d_histos["h_Mass_NJetsVSstop1_PtRank_"+cutVar.first]->GetXaxis()->SetTitle("N_{J}");
             //my_2d_histos["h_Mass_NJetsVSstop1_PtRank_"+cutVar.first]->GetYaxis()->SetTitle("Pt Rank M_{#tildet}_{1}"); 
@@ -587,7 +608,8 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
             //my_2d_histos["h_stopMasses_diffVSavg_"+cutVar.first]->Fill( difference_stopMasses, average_stopMasses, weight);
             //my_2d_histos["h_stopMasses_diffVSavg_"+cutVar.first]->GetXaxis()->SetTitle("difference");
             //my_2d_histos["h_stopMasses_diffVSavg_"+cutVar.first]->GetYaxis()->SetTitle("average");
-            //// stop All Pt combinations
+            
+            // stop All Pt combinations
             //my_2d_histos["h_ScalarPt_stop1vsstop2_ScalarPtRank_"+cutVar.first]->Fill( stop1ScalarPt_ScalarPtRank, stop2ScalarPt_ScalarPtRank, weight );
             //my_2d_histos["h_ScalarPt_stop1vsstop2_ScalarPtRank_"+cutVar.first]->GetXaxis()->SetTitle("ScalarPt Rank Scalar pT_{#tildet}_{1}");
             //my_2d_histos["h_ScalarPt_stop1vsstop2_ScalarPtRank_"+cutVar.first]->GetYaxis()->SetTitle("ScalarPt Rank Scalar pT_{#tildet}_{2}");
@@ -603,7 +625,8 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
             //my_2d_histos["h_Pt2_PtRankVsScalarPt2_ScalarPtRank"+cutVar.first]->Fill( stop2Pt_PtRank, stop2ScalarPt_ScalarPtRank, weight );
             //my_2d_histos["h_Pt2_PtRankVsScalarPt2_ScalarPtRank"+cutVar.first]->GetXaxis()->SetTitle("Pt Rank pT_{#tildet}_{2}");
             //my_2d_histos["h_Pt2_PtRankVsScalarPt2_ScalarPtRank"+cutVar.first]->GetYaxis()->SetTitle("ScalarPt Rank Scalar pT_{#tildet}_{2}");
-            //// stops MassVsPt
+            
+            // stops MassVsPt
             //my_2d_histos["h_stop1_MassVsPt_PtRank_"+cutVar.first]->Fill(stop1Mass_PtRank, stop1Pt_PtRank, weight);
             //my_2d_histos["h_stop1_MassVsPt_PtRank_"+cutVar.first]->GetXaxis()->SetTitle("Pt Rank M_{#tildet}_{1}");
             //my_2d_histos["h_stop1_MassVsPt_PtRank_"+cutVar.first]->GetYaxis()->SetTitle("Pt Rank pT_{#tildet}_{1}");
@@ -628,7 +651,8 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
             //my_2d_histos["h_stop2_MassVsScalarPt_ScalarPtRank_"+cutVar.first]->Fill(stop2Mass_ScalarPtRank, stop1ScalarPt_ScalarPtRank, weight);
             //my_2d_histos["h_stop2_MassVsScalarPt_ScalarPtRank_"+cutVar.first]->GetXaxis()->SetTitle("ScalarPt Rank M_{#tildet}_{2}");
             //my_2d_histos["h_stop2_MassVsScalarPt_ScalarPtRank_"+cutVar.first]->GetYaxis()->SetTitle("ScalarPt Rank Scalar pT_{#tildet}_{2}");
-            //// MT2
+
+            // MT2
             //my_2d_histos["h_NJetsVsMT2_"+cutVar.first]->Fill( NGoodJets_pt45, MT2, weight );
             //my_2d_histos["h_NJetsVsMT2_"+cutVar.first]->GetXaxis()->SetTitle("N_{J}");
             //my_2d_histos["h_NJetsVsMT2_"+cutVar.first]->GetYaxis()->SetTitle("MT2");
@@ -655,21 +679,21 @@ void Semra_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
             // -- stop gen level
             // --------------------
             // Reco
-            my_histos["h_StopRecoMT2_"+cutVar.first]->Fill( StopRecoMT2, weight );    
-            my_histos["h_Stop1RecoMass_"+cutVar.first]->Fill( Stop1RecoMass, weight );
-            my_histos["h_Stop2RecoMass_"+cutVar.first]->Fill( Stop2RecoMass, weight );
-            my_histos["h_Nlino1RecoMass_"+cutVar.first]->Fill( Nlino1RecoMass, weight );
-            my_histos["h_Nlino2RecoMass_"+cutVar.first]->Fill( Nlino2RecoMass, weight );
-            my_histos["h_Single1RecoMass_"+cutVar.first]->Fill( Single1RecoMass, weight );
-            my_histos["h_Single2RecoMass_"+cutVar.first]->Fill( Single2RecoMass, weight );
+            //my_histos["h_StopRecoMT2_"+cutVar.first]->Fill( StopRecoMT2, weight );    
+            //my_histos["h_Stop1RecoMass_"+cutVar.first]->Fill( Stop1RecoMass, weight );
+            //my_histos["h_Stop2RecoMass_"+cutVar.first]->Fill( Stop2RecoMass, weight );
+            //my_histos["h_Nlino1RecoMass_"+cutVar.first]->Fill( Nlino1RecoMass, weight );
+            //my_histos["h_Nlino2RecoMass_"+cutVar.first]->Fill( Nlino2RecoMass, weight );
+            //my_histos["h_Single1RecoMass_"+cutVar.first]->Fill( Single1RecoMass, weight );
+            //my_histos["h_Single2RecoMass_"+cutVar.first]->Fill( Single2RecoMass, weight );
             // Gen
-            my_histos["h_StopGenMT2_"+cutVar.first]->Fill( StopGenMT2, weight );
-            my_histos["h_Stop1GenMass_"+cutVar.first]->Fill( Stop1GenMass, weight );
-            my_histos["h_Stop2GenMass_"+cutVar.first]->Fill( Stop2GenMass, weight );
-            my_histos["h_Nlino1GenMass_"+cutVar.first]->Fill( Nlino1GenMass, weight );
-            my_histos["h_Nlino2GenMass_"+cutVar.first]->Fill( Nlino2GenMass, weight );
-            my_histos["h_Single1GenMass_"+cutVar.first]->Fill( Single1GenMass, weight );
-            my_histos["h_Single2RecoMass_"+cutVar.first]->Fill( Single2GenMass, weight );
+            //my_histos["h_StopGenMT2_"+cutVar.first]->Fill( StopGenMT2, weight );
+            //my_histos["h_Stop1GenMass_"+cutVar.first]->Fill( Stop1GenMass, weight );
+            //my_histos["h_Stop2GenMass_"+cutVar.first]->Fill( Stop2GenMass, weight );
+            //my_histos["h_Nlino1GenMass_"+cutVar.first]->Fill( Nlino1GenMass, weight );
+            //my_histos["h_Nlino2GenMass_"+cutVar.first]->Fill( Nlino2GenMass, weight );
+            //my_histos["h_Single1GenMass_"+cutVar.first]->Fill( Single1GenMass, weight );
+            //my_histos["h_Single2RecoMass_"+cutVar.first]->Fill( Single2GenMass, weight );
 
             }
         }

--- a/Analyzer/test/Stack_plot_0l.C
+++ b/Analyzer/test/Stack_plot_0l.C
@@ -410,22 +410,25 @@ int main()
     // entry for data
     // --------------
     // 'leg entry'  'root file'     'draw options'  'draw color'
-    histInfo data = {"Data", "condor/MT2_stopHemispheres/19th_presentation/hadd_2016_MC_HemisphereJets_pt45WithGoodJetRequirements_seed2_Assc3_wp0.98/2016_BG_OTHER.root", "PEX0", kBlack, false};
+    histInfo data = {"Data", "condor/hadd_2016_wholeTT_WP98_GoodJetsMaskTest_16.07.2020/2016_BG_OTHER.root", "PEX0", kBlack, false};
 
     // ----------------------------------------
     // vector summarizing background histograms 
     // ----------------------------------------
     std::vector<histInfo> bgEntries = {
 
-        {"T#bar{T}",        "condor/MT2_stopHemispheres/19th_presentation/hadd_2016_MC_HemisphereJets_pt45WithGoodJetRequirements_seed2_Assc3_wp0.98/2016_TT.root",              "hist", kBlue - 6   },
-        {"WJets",           "condor/MT2_stopHemispheres/19th_presentation/hadd_2016_MC_HemisphereJets_pt45WithGoodJetRequirements_seed2_Assc3_wp0.98/2016_WJets.root",           "hist", kYellow + 1 },
-        {"DYJetsToLL_M-50", "condor/MT2_stopHemispheres/19th_presentation/hadd_2016_MC_HemisphereJets_pt45WithGoodJetRequirements_seed2_Assc3_wp0.98/2016_DYJetsToLL_M-50.root", "hist", kOrange + 2 },
-        {"QCD",             "condor/MT2_stopHemispheres/19th_presentation/hadd_2016_MC_HemisphereJets_pt45WithGoodJetRequirements_seed2_Assc3_wp0.98/2016_QCD.root",             "hist", kGreen + 1  },
-        {"ST",              "condor/MT2_stopHemispheres/19th_presentation/hadd_2016_MC_HemisphereJets_pt45WithGoodJetRequirements_seed2_Assc3_wp0.98/2016_ST.root",              "hist", kRed + 1    },
-        {"Diboson",         "condor/MT2_stopHemispheres/19th_presentation/hadd_2016_MC_HemisphereJets_pt45WithGoodJetRequirements_seed2_Assc3_wp0.98/2016_Diboson.root",         "hist", kMagenta + 1},
-        {"TTX",             "condor/MT2_stopHemispheres/19th_presentation/hadd_2016_MC_HemisphereJets_pt45WithGoodJetRequirements_seed2_Assc3_wp0.98/2016_TTX.root",             "hist", kCyan + 1   },
-        {"Triboson",        "condor/MT2_stopHemispheres/19th_presentation/hadd_2016_MC_HemisphereJets_pt45WithGoodJetRequirements_seed2_Assc3_wp0.98/2016_Triboson.root",        "hist", kGray       },
+        {"t#bar{t}",        "condor/hadd_2016_wholeTT_WP98_GoodJetsMaskTest_16.07.2020/2016_TT.root",              "hist", kBlue - 6    },
+        {"t#bar{t}+X",      "condor/hadd_2016_wholeTT_WP98_GoodJetsMaskTest_16.07.2020/2016_TTX.root",             "hist", kOrange + 2   },
+        {"QCD",             "condor/hadd_2016_wholeTT_WP98_GoodJetsMaskTest_16.07.2020/2016_QCD.root",             "hist", kGreen + 1  },
+        {"Other",           "condor/hadd_2016_wholeTT_WP98_GoodJetsMaskTest_16.07.2020/2016_Other.root",           "hist", kMagenta + 2  },
+         
+        //{"WJets",           "condor/hadd_2016_wholeTT_WP98_GoodJetsMaskTest_16.07.2020/2016_WJets.root",           "hist", kYellow + 1 },
+        //{"DYJetsToLL_M-50", "condor/hadd_2016_wholeTT_WP98_GoodJetsMaskTest_16.07.2020/2016_DYJetsToLL_M-50.root", "hist", kOrange + 2 },
+        //{"ST",              "condor/hadd_2016_wholeTT_WP98_GoodJetsMaskTest_16.07.2020/2016_ST.root",              "hist", kRed + 1    },
+        //{"Diboson",         "condor/hadd_2016_wholeTT_WP98_GoodJetsMaskTest_16.07.2020/2016_Diboson.root",         "hist", kMagenta + 1},
+        //{"Triboson",        "condor/hadd_2016_wholeTT_WP98_GoodJetsMaskTest_16.07.2020/2016_Triboson.root",        "hist", kGray       },
 
+    
     };
     
     // ------------------------------------
@@ -433,10 +436,10 @@ int main()
     // ------------------------------------ 
     std::vector<histInfo> sigEntries = { 
 
-        {"RPV m_{#tildet} = 350", "condor/MT2_stopHemispheres/19th_presentation/hadd_2016_MC_HemisphereJets_pt45WithGoodJetRequirements_seed2_Assc3_wp0.98/2016_RPV_2t6j_mStop-350.root",        "hist", kCyan    }, 
-        {"RPV m_{#tildet} = 550", "condor/MT2_stopHemispheres/19th_presentation/hadd_2016_MC_HemisphereJets_pt45WithGoodJetRequirements_seed2_Assc3_wp0.98/2016_RPV_2t6j_mStop-550.root",        "hist", kMagenta },
-        {"RPV m_{#tildet} = 850", "condor/MT2_stopHemispheres/19th_presentation/hadd_2016_MC_HemisphereJets_pt45WithGoodJetRequirements_seed2_Assc3_wp0.98/2016_RPV_2t6j_mStop-850.root",        "hist", kRed },
-        //{"SYY m_{#tildet} = 900", "condor/hadd_2016_MC_HemisphereJets_pt45WithGoodJetRequirements_seed2_Assc3_wp0.98/2016_StealthSYY_2t6j_mStop-900.root", "hist", k    },
+        {"RPV m_{#tildet} = 350", "condor/hadd_2016_wholeTT_WP98_GoodJetsMaskTest_16.07.2020/2016_RPV_2t6j_mStop-350.root",        "hist", kCyan+1    }, 
+        {"RPV m_{#tildet} = 550", "condor/hadd_2016_wholeTT_WP98_GoodJetsMaskTest_16.07.2020/2016_RPV_2t6j_mStop-550.root",        "hist", kMagenta+2 },
+        {"RPV m_{#tildet} = 850", "condor/hadd_2016_wholeTT_WP98_GoodJetsMaskTest_16.07.2020/2016_RPV_2t6j_mStop-850.root",        "hist", kRed },
+        //{"SYY m_{#tildet} = 900", "condor/hadd_2016_wholeTT_WP98_GoodJetsMaskTest_16.07.2020/2016_StealthSYY_2t6j_mStop-900.root", "hist", kGray },
     
     };
 
@@ -466,28 +469,30 @@ int main()
 
     for (const auto& cutlabel : cut) 
     {
-        //plt.plot( "h_ntops_"+cutlabel,          "N_{T}",                "Events", true, cutlabel );
-        //plt.plot( "h_njets_"+cutlabel,          "N_{J}",                "Events", true, cutlabel );
-        //plt.plot( "h_nbjets_"+cutlabel,         "N_{BJ}",               "Events", true, cutlabel );
-        //plt.plot( "h_ht_"+cutlabel,             "HT [GeV]",             "Events", true, cutlabel );
-        //plt.plot( "h_met_"+cutlabel,            "MET [GeV]",            "Events", true, cutlabel );
-        //plt.plot( "h_jetsPt_"+cutlabel,         "pT_{Jets} [GeV]",      "Events", true, cutlabel );     
-        //plt.plot( "h_jetsMass_"+cutlabel,       "M_{Jets} [GeV]",       "Events", true, cutlabel ); 
-        //plt.plot( "h_bjetsPt_"+cutlabel,        "pT_{BJets} [GeV]",     "Events", true, cutlabel ); 
-        //plt.plot( "h_bjetsMass_"+cutlabel,      "M_{BJets} [GeV]",      "Events", true, cutlabel ); 
-        //plt.plot( "h_topsMass_"+cutlabel,       "M_{Tops} [GeV]",       "Events", true, cutlabel );
-        //plt.plot( "h_topsEta_"+cutlabel,        "#eta_{Tops} [GeV]",    "Events", true, cutlabel );
-        //plt.plot( "h_topsPt_"+cutlabel,         "pT_{Tops} [GeV]",      "Events", true, cutlabel );
-        //plt.plot( "h_bestTopMass_"+cutlabel,    "M_{BestTop} [GeV]",    "Events", true, cutlabel );
-        //plt.plot( "h_bestTopEta_"+cutlabel,     "#eta_{BestTop} [GeV]", "Events", true, cutlabel );         
-        //plt.plot( "h_bestTopPt_"+cutlabel,      "pT_{BestTop} [GeV]",   "Events", true, cutlabel );
-        //plt.plot( "h_dR_bjet1_bjet2_"+cutlabel, "#DeltaR_{bj1-bj2}",    "Events", true, cutlabel );
-        //plt.plot( "h_dR_top1_top2_"+cutlabel,   "#DeltaR_{t1-t2}",      "Events", true, cutlabel );
-        //plt.plot( "h_dR_tops_bjets_"+cutlabel,  "#DeltaR_{tops-bjets}", "Events", true, cutlabel ); 
+        plt.plot( "h_ntops_"+cutlabel,        "N_{T}",              "Events", true, cutlabel );
+        plt.plot( "h_njets_"+cutlabel,        "N_{J}",              "Events", true, cutlabel );
+        plt.plot( "h_nbjets_"+cutlabel,       "N_{BJ}",             "Events", true, cutlabel );
+        plt.plot( "h_ht_"+cutlabel,           "HT [GeV]",           "Events", true, cutlabel );
+        plt.plot( "h_met_"+cutlabel,          "MET [GeV]",          "Events", true, cutlabel );
 
-        //plt.plot( "h_dR_bjet1_bjet2_"+cutlabel, "#DeltaR_{bj1-bj2}",    "Events", false, cutlabel ); // for log scale 
-        //plt.plot( "h_dR_top1_top2_"+cutlabel,   "#DeltaR_{t1-t2}",      "Events", false, cutlabel );
-        //plt.plot( "h_dR_tops_bjets_"+cutlabel,  "#DeltaR_{tops-bjets}", "Events", false, cutlabel );
+        plt.plot( "h_topsMass_"+cutlabel,      "M_{Tops} [GeV]",       "Events", true, cutlabel, 0, 50);
+        plt.plot( "h_topsEta_"+cutlabel,       "#eta_{Tops}",          "Events", true, cutlabel, 5 );
+        plt.plot( "h_topsPhi_"+cutlabel,       "#phi_{Tops}",          "Events", true, cutlabel, 5 );
+        plt.plot( "h_topsPt_"+cutlabel,        "pT_{Tops} [GeV]",      "Events", true, cutlabel, 0, 500);
+
+        plt.plot( "h_resolvedMass_"+cutlabel,  "resolved jet M",       "Events", true, cutlabel, 0, 50);
+        plt.plot( "h_resolvedEta_"+cutlabel,   "resolved jet #eta",    "Events", true, cutlabel, 5 );
+        plt.plot( "h_resolvedPhi_"+cutlabel,   "resolved jet #phi",    "Events", true, cutlabel, 5 );
+        plt.plot( "h_resolvedPt_"+cutlabel,    "resolved jet pT",      "Events", true, cutlabel, 0, 500);
+
+        plt.plot( "h_bestTopMass_"+cutlabel,   "M_{BestTop} [GeV]",    "Events", true, cutlabel );
+        plt.plot( "h_bestTopEta_"+cutlabel,    "#eta_{BestTop}",       "Events", true, cutlabel );         
+        plt.plot( "h_bestTopPt_"+cutlabel,     "pT_{BestTop} [GeV]",   "Events", true, cutlabel );
+
+        plt.plot( "h_dR_bjets_"+cutlabel,      "#DeltaR_{bjets}",      "Events", false, cutlabel ); // true: for not log scale
+        plt.plot( "h_dR_top1_top2_"+cutlabel,  "#DeltaR_{t1-t2}",      "Events", false, cutlabel );
+        plt.plot( "h_dR_tops_bjets_"+cutlabel, "#DeltaR_{tops-bjets}", "Events", false, cutlabel ); 
+
 
         // stop MT2 hemispheres 
         //plt.plot( "h_stop1Mass_PtRank_"+cutlabel,           "Pt Rank M_{#tildet}_{1}",               "Events", true, cutlabel, 0, 1500, 5 );
@@ -526,11 +531,6 @@ int main()
         //plt.plot( "h_difference_stopMasses_"+cutlabel,      "Pt Rank difference",                    "Events", true, cutlabel, 0, 1500, 5 );
         //plt.plot( "h_average_stopMasses_"+cutlabel,         "average",                               "Events", true, cutlabel, 0, 1500, 5 );
         //plt.plot( "h_relativeDiff_stopMasses_"+cutlabel,    "Pt Rank relative difference",           "Events", true, cutlabel, 0, 100,  5 );
-
-        plt.plot( "h_resolvedMass_"+cutlabel,               "resolved jet M",                        "Events", true, cutlabel, 0, 50);
-        plt.plot( "h_resolvedEta_"+cutlabel,                "resolved jet #eta",                     "Events", true, cutlabel, 5 );
-        plt.plot( "h_resolvedPhi_"+cutlabel,                "resolved jet #phi",                     "Events", true, cutlabel, 5 );
-        plt.plot( "h_resolvedPt_"+cutlabel,                 "resolved jet pT",                       "Events", true, cutlabel, 0, 500);
 
     }
 }


### PR DESCRIPTION
(1) Updated the AnalyzeTopTagger.cc file to fix the memory leak problem.
     -- This analyzer uses the /TopTaggerToos/Tools/include/HistoContainer.h file to get the histograms for fake rate and efficiency study. 

**Note that:
(1) Use the AnalyzeTopTagger.cc for fake rate & efficiency 
(2) Need to set up top tagger (RunTopTagger.h in Framework repository) to use which algorithm you want to test
(3) Separate branch which is "Stealth" in TopTaggerTools repository for the fake rate and efficiency plotting. 