### PR TITLE
Add scripts that make more official plots for legacy 1L analysis

### DIFF
--- a/Analyzer/test/HistInfoCollectionLegacyAna.h
+++ b/Analyzer/test/HistInfoCollectionLegacyAna.h
@@ -1,0 +1,263 @@
+#ifndef HISTINFOCOLLECTIONLEGACYANA_H
+#define HISTINFOCOLLECTIONLEGACYANA_H
+
+#include "TH1.h"
+#include "THStack.h"
+#include "TFile.h"
+#include "TCanvas.h"
+#include "TLegend.h"
+#include "TLatex.h"
+#include "TGraph.h"
+#include "TGraphErrors.h"
+#include "TF1.h"
+
+#include <memory>
+#include <vector>
+#include <string>
+#include <cstdio>
+#include <iostream>
+#include <map>
+
+//Class to hold TH1* with various helper functions 
+class histInfo
+{
+public:
+    std::string legName, histFile, histName, drawOptions, legEntry;
+    int color, rebin;
+    double scale; 
+    bool norm2Data;
+    int lineStyle;
+    std::shared_ptr<TH1> h;
+    std::shared_ptr<TGraphErrors> ge;
+
+    // Merge the njets >= 12 bins together
+    void fixNJetsHisto(std::shared_ptr<TH1>& njetsHisto)
+    {
+
+        int nbinsX = njetsHisto->GetNbinsX();
+        int bin12jet = njetsHisto->FindBin(12.2);
+        for (int bin = bin12jet+1; bin < nbinsX; bin++) {
+
+        
+            double content = njetsHisto->GetBinContent(bin);
+            njetsHisto->Fill(12.2, content);
+
+            njetsHisto->SetBinContent(bin, 0.0);
+            njetsHisto->SetBinError(bin, 0.0);
+
+        }
+    }
+
+    //helper function to get histogram from file and configure its optional settings
+    void retrieveHistogram()
+    {
+        //Open the file for this histogram
+        TFile *f = TFile::Open(histFile.c_str());
+
+        //check that the file was opened successfully
+        if(!f)
+        {
+            printf("File \"%s\" could not be opened!!!\n", histFile.c_str());
+            h = nullptr;
+            return;
+        }
+
+        //get the histogram from the file
+        h.reset(static_cast<TH1*>(f->Get(histName.c_str())));
+
+        ge.reset(new TGraphErrors(static_cast<TH1*>(f->Get(histName.c_str()))));
+
+        if (histName.find("njets") != std::string::npos) { fixNJetsHisto(h); }
+
+        //with the histogram retrieved, close the file
+        f->Close();
+        delete f;
+
+        //check that the histogram was retireved from the file successfully
+        if(!h)
+        {
+            printf("Histogram \"%s\" could not be found in file \"%s\"!!!\n", histName.c_str(), histFile.c_str());
+            return;
+        }
+
+        //set the histogram color
+        h->SetLineColor(color);
+        h->SetLineWidth(3);
+        h->SetMarkerColor(color);
+        h->SetMarkerStyle(20);
+        h->Scale(scale);
+
+        ge->SetLineWidth(0);
+        ge->SetMarkerSize(0);
+        ge->SetFillStyle(3254);
+        ge->SetFillColor(kBlack);
+        
+        legEntry = legName;
+
+        // rebin the histogram if desired
+        if(rebin >0) h->Rebin(rebin);
+    }
+
+    //helper function for axes
+    void setupAxes(double xOffset, double yOffset, double xTitle, double yTitle, double xLabel, double yLabel)
+    {
+        h->SetStats(0);
+        h->SetTitle(0);
+        h->GetXaxis()->SetTitleOffset(xOffset);
+        h->GetYaxis()->SetTitleOffset(yOffset);
+        h->GetXaxis()->SetTitleSize(xTitle);
+        h->GetYaxis()->SetTitleSize(yTitle);
+        h->GetXaxis()->SetLabelSize(xLabel);
+        h->GetYaxis()->SetLabelSize(yLabel);
+        if(h->GetXaxis()->GetNdivisions() % 100 > 5) h->GetXaxis()->SetNdivisions(6, 5, 0);
+    }
+
+    //helper function for pads
+    void setupPad(double left, double right, double top, double bottom)
+    {
+        gPad->SetLeftMargin(left);
+        gPad->SetRightMargin(right);
+        gPad->SetTopMargin(top);
+        gPad->SetBottomMargin(bottom);
+        gPad->SetTicks(1,1);
+    }
+
+    //wrapper to draw histogram
+    void draw(const std::string& additionalOptions = "", bool noSame = false) const
+    {
+        h->Draw(((noSame?"":"same " + drawOptions + " " + additionalOptions)).c_str());
+    }
+
+    void setFillColor(int newColor = -1)
+    {
+        if(newColor >= 0) h->SetFillColor(newColor);
+        else              h->SetFillColor(color);
+    }
+
+    void setLineStyle(int style = 1)
+    {
+        h->SetLineStyle(style);
+    }
+
+    histInfo(const std::string& legName, const std::string& histFile, const std::string& drawOptions, const int color, const double scale = 1.0, const bool norm2Data = false, int lineStyle = 0) : legName(legName), histFile(histFile), histName(""), drawOptions(drawOptions), color(color), rebin(-1), scale(scale), norm2Data(norm2Data), lineStyle(lineStyle), h(nullptr)
+    {
+    }
+
+    histInfo(TH1* h) : legName(h->GetName()), histFile(""), histName(h->GetName()), drawOptions(""), color(kWhite), rebin(0), scale(1.0), h(h)
+    {
+    }
+
+    ~histInfo()
+    {
+    }
+};
+
+class HistInfoCollection
+{
+public:
+    std::vector<histInfo> dataVec_, bgVec_, sigVec_, systVec_, rsystVec_;
+
+    HistInfoCollection(std::vector<histInfo>&& dataVec, std::vector<histInfo>&& bgVec, std::vector<histInfo>&& sigVec, std::vector<histInfo>&& systVec, std::vector<histInfo>&& rsystVec) : dataVec_(dataVec), bgVec_(bgVec), sigVec_(sigVec), systVec_(systVec), rsystVec_(rsystVec) {}
+    HistInfoCollection(std::vector<histInfo>& dataVec, std::vector<histInfo>& bgVec, std::vector<histInfo>& sigVec, std::vector<histInfo>& systVec, std::vector<histInfo>& rsystVec) : dataVec_(dataVec), bgVec_(bgVec), sigVec_(sigVec), systVec_(systVec), rsystVec_(rsystVec) {}
+    HistInfoCollection() {};
+
+    ~HistInfoCollection() {}
+
+    void setUpBG(const std::string& histName, int rebin, THStack* bgStack, std::shared_ptr<TH1>& hbgSum, const bool& setFill = true, const bool& scale = false)
+    {
+        if (dataVec_.size() != 0 and bgVec_.size() != 0) {
+            double dNum = 1, bNum = 1;
+            if(scale)
+            {
+                dNum = 0;
+                bNum = 0;
+                for(auto& entry : dataVec_)
+                {
+                    entry.histName = histName;
+                    entry.rebin = rebin;
+                    entry.retrieveHistogram();            
+                    dNum += entry.h->Integral(); 
+                }
+                for(auto& entry : bgVec_)
+                {
+                    entry.histName = histName;
+                    entry.rebin = rebin;
+                    entry.retrieveHistogram();
+                    bNum += entry.h->Integral();
+                } 
+            }
+            
+            bool firstPass = true;
+            for(auto& entry : bgVec_)
+            {
+                entry.histName = histName;
+                entry.rebin = rebin;
+                entry.retrieveHistogram();
+                if (entry.norm2Data) entry.h->Scale(dNum/bNum);
+
+                bgStack->Add(entry.h.get(), entry.drawOptions.c_str());
+                if(firstPass) 
+                {
+                    hbgSum.reset( static_cast<TH1*>(entry.h->Clone()) );
+                    firstPass = false;
+                }
+                else 
+                {
+                    hbgSum->Add(entry.h.get());
+                }
+                
+                if(setFill)
+                {
+                    entry.setFillColor();
+                }
+            }
+        }
+    }
+
+    void setUpSignal(const std::string& histName, int rebin)
+    {
+        if (sigVec_.size() != 0) {
+
+            for(auto& entry : sigVec_)
+            {
+                entry.histName = histName;
+                entry.rebin = rebin;
+                entry.retrieveHistogram();
+                entry.h->Scale(entry.scale);
+                entry.setLineStyle(entry.lineStyle);    
+            }
+        }
+    }
+
+    void setUpData(const std::string& histName, int rebin)
+    {
+        if (dataVec_.size() != 0) {
+            for(auto& entry : dataVec_)
+            {
+                entry.histName = histName;
+                entry.rebin = rebin;
+                entry.retrieveHistogram();
+            }
+        }
+    }
+
+    void setUpSyst(const std::string& histName)
+    {
+        if (systVec_.size() != 0) {
+
+            for(auto& entry : systVec_)
+            {
+                entry.histName = histName;
+                entry.retrieveHistogram();
+            }
+
+            for(auto& entry : rsystVec_)
+            {
+            entry.histName = histName;
+            entry.retrieveHistogram();
+            }
+        }
+    }
+};
+
+#endif

--- a/Analyzer/test/Makefile.in
+++ b/Analyzer/test/Makefile.in
@@ -57,7 +57,7 @@ endif
 # Include our code
 INCLUDESDIRS += -I$(TDIR) -I$(IFWDIR) -I$(SFWDIR) -I$(IADIR) -I$(SADIR) -I$(SSDIR) -I$(ITTDir) -I$(STTDir)
 
-PROGRAMS = MyAnalysis plot_1l Stack_plot_0l Stack_plot_1l Stack_plot_2l
+PROGRAMS = MyAnalysis plot_1l plot_1l_LegacyAna Stack_plot_0l Stack_plot_1l Stack_plot_2l
 
 ANALYZERS  = $(ODIR)/MiniTupleMaker.o $(ODIR)/CalculateBTagSF.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/MakeMiniTree.o $(ODIR)/AnalyzeLepTrigger.o $(ODIR)/AnalyzeTest.o 
 ANALYZERS += $(ODIR)/AnalyzeWControlRegion.o $(ODIR)/MakeMiniTree.o $(ODIR)/MiniTupleMaker.o $(ODIR)/CalculateBTagSF.o $(ODIR)/AnalyzeBTagSF.o $(ODIR)/BTagCalibrationStandalone.o 
@@ -98,6 +98,9 @@ MyAnalysis: $(ODIR)/MyAnalysis.o $(HELPERS) $(ANALYZERS)
 	$(LD) $^ $(LIBSTOPTAGGER) $(LIBS) -o $@
 
 plot_1l: $(ODIR)/plot_1l.o
+	$(LD) $^ $(LIBS) -o $@
+
+plot_1l_LegacyAna: $(ODIR)/plot_1l_LegacyAna.o
 	$(LD) $^ $(LIBS) -o $@
 
 Stack_plot_0l: $(ODIR)/Stack_plot_0l.o

--- a/Analyzer/test/makeBinEdgePlotLegacyAna.py
+++ b/Analyzer/test/makeBinEdgePlotLegacyAna.py
@@ -1,0 +1,285 @@
+#!/bin/python
+import ROOT
+import math
+import argparse
+
+lb = ROOT.TColor.GetColor("#CDE4F1")
+db = ROOT.TColor.GetColor("#98C8E3")
+lg = ROOT.TColor.GetColor("#95C495")
+dg = ROOT.TColor.GetColor("#499948")
+
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat("")
+
+binNames = ["7", "8", "9", "10", "11", "#geq 12"]
+
+usage = "usage: %prog [options]"
+parser = argparse.ArgumentParser(usage)
+parser.add_argument("--approved", dest="approved", help="Plot is approved", action="store_true", default=False) 
+
+args = parser.parse_args()
+
+def makeBinFill(e2, e1, name, color):
+
+    g = ROOT.TGraphErrors(6); g.SetName(name)
+
+    for edge in xrange(0, len(e1)):
+
+        g.SetPoint(edge, float(edge+0.5), e2[edge] - (e2[edge]-e1[edge])/2.0)
+        g.SetPointError(edge, 0.5, (e2[edge]-e1[edge])/2.0) 
+
+    g.SetFillColorAlpha(color,1.0)
+    g.SetLineWidth(0)
+    g.SetMarkerSize(0)
+
+    return g
+
+def makeBinEdges(e, name):
+
+    h = ROOT.TH1F(name, name, 6, 0, 6); h.SetDirectory(0)
+    h.GetYaxis().SetRangeUser(0,1)
+
+    for edge in xrange(1, 7):
+        h.SetBinContent(edge, e[edge-1])
+        h.SetBinError(edge, 0.0)
+
+    h.GetYaxis().SetTitle("S_{NN}")
+    h.GetXaxis().SetTitle("Number of Jets")
+
+    for bin in xrange(1,h.GetNbinsX()+1): h.GetXaxis().SetBinLabel(bin, binNames[bin-1])
+    
+    h.GetXaxis().SetTitleSize(0.065)
+    h.GetYaxis().SetTitleSize(0.065)
+
+    h.GetXaxis().SetLabelSize(0.085)
+    h.GetYaxis().SetLabelSize(0.055)
+
+    h.GetYaxis().SetLabelOffset(0.015)
+
+    h.GetXaxis().SetTitleOffset(0.8)
+    h.GetYaxis().SetTitleOffset(1.05)
+
+    h.SetTitle("")
+
+    h.SetLineWidth(2)
+    h.SetMarkerSize(0)
+
+    h.SetLineColor(ROOT.kBlue+3)
+    h.SetMarkerColor(ROOT.kBlue+3)
+
+    return h
+
+def main() :
+
+    edges_0 = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    edges_1 = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+
+    edges16_1 = [0.349, 0.358, 0.371, 0.386, 0.410, 0.410]
+    edges16_2 = [0.680, 0.740, 0.787, 0.816, 0.848, 0.853]
+    edges16_3 = [0.835, 0.878, 0.901, 0.917, 0.936, 0.936]
+
+    edges17_1 = [0.346, 0.363, 0.376, 0.384, 0.396, 0.396]
+    edges17_2 = [0.714, 0.752, 0.780, 0.794, 0.801, 0.801]
+    edges17_3 = [0.833, 0.864, 0.885, 0.895, 0.901, 0.901]
+
+    edges18_1 = [0.345, 0.363, 0.374, 0.386, 0.386, 0.386]
+    edges18_2 = [0.713, 0.752, 0.779, 0.805, 0.805, 0.805]
+    edges18_3 = [0.832, 0.863, 0.883, 0.900, 0.911, 0.911]
+
+    edges19_1 = [0.364, 0.386, 0.405, 0.411, 0.411, 0.411]
+    edges19_2 = [0.729, 0.771, 0.798, 0.826, 0.826, 0.826]
+    edges19_3 = [0.842, 0.874, 0.895, 0.914, 0.914, 0.914]
+
+    h16_1 = makeBinEdges(edges16_1, "edges16_1")
+    h16_2 = makeBinEdges(edges16_2, "edges16_2")
+    h16_3 = makeBinEdges(edges16_3, "edges16_3")
+
+    h17_1 = makeBinEdges(edges17_1, "edges17_1")
+    h17_2 = makeBinEdges(edges17_2, "edges17_2")
+    h17_3 = makeBinEdges(edges17_3, "edges17_3")
+
+    h18_1 = makeBinEdges(edges18_1, "edges18_1")
+    h18_2 = makeBinEdges(edges18_2, "edges18_2")
+    h18_3 = makeBinEdges(edges18_3, "edges18_3")
+
+    h19_1 = makeBinEdges(edges19_1, "edges19_1")
+    h19_2 = makeBinEdges(edges19_2, "edges19_2")
+    h19_3 = makeBinEdges(edges19_3, "edges19_3")
+
+
+    f16_1 = makeBinFill(edges16_1, edges_0,   "fill16_1", db)
+    f16_2 = makeBinFill(edges16_2, edges16_1, "fill16_2", lb)
+    f16_3 = makeBinFill(edges16_3, edges16_2, "fill16_3", lg)
+    f16_4 = makeBinFill(edges_1, edges16_3,   "fill16_4", dg)
+
+    f17_1 = makeBinFill(edges17_1, edges_0,   "fill17_1", db)
+    f17_2 = makeBinFill(edges17_2, edges17_1, "fill17_2", lb)
+    f17_3 = makeBinFill(edges17_3, edges17_2, "fill17_3", lg)
+    f17_4 = makeBinFill(edges_1, edges17_3,   "fill17_4", dg)
+
+    f18_1 = makeBinFill(edges18_1, edges_0,   "fill18_1", db)
+    f18_2 = makeBinFill(edges18_2, edges18_1, "fill18_2", lb)
+    f18_3 = makeBinFill(edges18_3, edges18_2, "fill18_3", lg)
+    f18_4 = makeBinFill(edges_1, edges18_3,   "fill18_4", dg)
+
+    f19_1 = makeBinFill(edges19_1, edges_0,   "fill19_1", db)
+    f19_2 = makeBinFill(edges19_2, edges19_1, "fill19_2", lb)
+    f19_3 = makeBinFill(edges19_3, edges19_2, "fill19_3", lg)
+    f19_4 = makeBinFill(edges_1, edges19_3,   "fill19_4", dg)
+
+    line1 = ROOT.TLine(1.0,0.0,1.0,1.0); line1.SetLineWidth(1); line1.SetLineColor(ROOT.kBlack); line1.SetLineStyle(3)
+    line2 = ROOT.TLine(2.0,0.0,2.0,1.0); line2.SetLineWidth(1); line2.SetLineColor(ROOT.kBlack); line2.SetLineStyle(3)
+    line3 = ROOT.TLine(3.0,0.0,3.0,1.0); line3.SetLineWidth(1); line3.SetLineColor(ROOT.kBlack); line3.SetLineStyle(3)
+    line4 = ROOT.TLine(4.0,0.0,4.0,1.0); line4.SetLineWidth(1); line4.SetLineColor(ROOT.kBlack); line4.SetLineStyle(3)
+    line5 = ROOT.TLine(5.0,0.0,5.0,1.0); line5.SetLineWidth(1); line5.SetLineColor(ROOT.kBlack); line5.SetLineStyle(3)
+    line6 = ROOT.TLine(6.0,0.0,6.0,1.0); line6.SetLineWidth(1); line6.SetLineColor(ROOT.kBlack); line6.SetLineStyle(3)
+
+    c1 = ROOT.TCanvas( "c1", "c1", 3200, 800 )
+
+    tm = 0.1; bm = 0.12; lm = 0.14; rm = 0.02
+
+    l1 = 0.277967; l2 = 0.239052; l3 = 0.239052; l4 = 0.24393
+
+    c1.Divide(4,1)
+    c1.cd(1)
+
+    ROOT.gPad.SetPad(0.0, 0.0, l1, 1.0)
+    ROOT.gPad.SetGridx()
+    ROOT.gPad.SetLeftMargin(lm)
+    ROOT.gPad.SetRightMargin(0.0)
+    ROOT.gPad.SetTopMargin(tm)
+    ROOT.gPad.SetBottomMargin(bm)
+
+
+    h16_1.Draw("HIST")
+    f16_1.Draw("2SAME")
+    f16_2.Draw("2SAME")
+    f16_3.Draw("2SAME")
+    f16_4.Draw("2SAME")
+    h16_1.Draw("HIST SAME")
+    h16_2.Draw("HIST SAME")
+    h16_3.Draw("HIST SAME")
+
+    line1.Draw("SAME")
+    line2.Draw("SAME")
+    line3.Draw("SAME")
+    line4.Draw("SAME")
+    line5.Draw("SAME")
+    line6.Draw("SAME")
+
+    mark = ROOT.TLatex();
+    mark.SetNDC(True);
+
+    mark.SetTextAlign(11)
+    mark.SetTextSize(0.065)
+    mark.SetTextFont(61)
+    mark.DrawLatex(ROOT.gPad.GetLeftMargin(), 1 - (ROOT.gPad.GetTopMargin() - 0.020), "CMS")
+    mark.SetTextAlign(31)
+    mark.SetTextSize(0.060)
+    mark.DrawLatex(1.0 - ROOT.gPad.GetRightMargin() - 0.01, 1 - (ROOT.gPad.GetTopMargin() - 0.020), "2016")
+    mark.SetTextFont(52)
+    mark.SetTextAlign(11)
+    if args.approved:
+        mark.DrawLatex(ROOT.gPad.GetLeftMargin() + 0.135, 1 - (ROOT.gPad.GetTopMargin() - 0.020), "Simulation Supplementary");
+    else:
+        mark.DrawLatex(ROOT.gPad.GetLeftMargin() + 0.135, 1 - (ROOT.gPad.GetTopMargin() - 0.020), "Simulation Preliminary");
+
+
+    c1.cd(2)
+    ROOT.gPad.SetPad(l1, 0.0, l1+l2, 1.0)
+    ROOT.gPad.SetLeftMargin(0.0)
+    ROOT.gPad.SetRightMargin(0.0)
+    ROOT.gPad.SetTopMargin(tm)
+    ROOT.gPad.SetBottomMargin(bm)
+
+    h17_1.Draw("HIST")
+    f17_1.Draw("2SAME")
+    f17_2.Draw("2SAME")
+    f17_3.Draw("2SAME")
+    f17_4.Draw("2SAME")
+    h17_1.Draw("HIST SAME")
+    h17_2.Draw("HIST SAME")
+    h17_3.Draw("HIST SAME")
+
+    mark.SetTextAlign(31)
+    mark.SetTextSize(0.055)
+    mark.SetTextFont(42)
+    mark.DrawLatex(1.0 - ROOT.gPad.GetLeftMargin() - 0.34, 1 - (ROOT.gPad.GetTopMargin() - 0.020), "arXiv:XXXX.XXXX")
+
+    mark.SetTextAlign(31)
+    mark.SetTextSize(0.065)
+    mark.SetTextFont(61)
+    mark.DrawLatex(1.0 - ROOT.gPad.GetRightMargin() - 0.01, 1 - (ROOT.gPad.GetTopMargin() - 0.020), "2017")
+
+    line1.Draw("SAME")
+    line2.Draw("SAME")
+    line3.Draw("SAME")
+    line4.Draw("SAME")
+    line5.Draw("SAME")
+    line6.Draw("SAME")
+
+    c1.cd(3)
+    ROOT.gPad.SetPad(l1+l2, 0.0, l1+l2+l3, 1.0)
+    ROOT.gPad.SetLeftMargin(0.0)
+    ROOT.gPad.SetRightMargin(0.0)
+    ROOT.gPad.SetTopMargin(tm)
+    ROOT.gPad.SetBottomMargin(bm)
+
+    h18_1.Draw("HIST")
+    f18_1.Draw("2SAME")
+    f18_2.Draw("2SAME")
+    f18_3.Draw("2SAME")
+    f18_4.Draw("2SAME")
+    h18_1.Draw("HIST SAME")
+    h18_2.Draw("HIST SAME")
+    h18_3.Draw("HIST SAME")
+
+    mark.SetTextAlign(31)
+    mark.SetTextSize(0.065)
+    mark.SetTextFont(61)
+
+    mark.DrawLatex(1.0 - ROOT.gPad.GetRightMargin() - 0.01, 1 - (ROOT.gPad.GetTopMargin() - 0.020), "2018A")
+
+    line1.Draw("SAME")
+    line2.Draw("SAME")
+    line3.Draw("SAME")
+    line4.Draw("SAME")
+    line5.Draw("SAME")
+    line6.Draw("SAME")
+
+    c1.cd(4)
+    ROOT.gPad.SetPad(1.0-l4, 0.0, 1.0, 1.0)
+    ROOT.gPad.SetLeftMargin(0.0)
+    ROOT.gPad.SetRightMargin(rm)
+    ROOT.gPad.SetTopMargin(tm)
+    ROOT.gPad.SetBottomMargin(bm)
+
+    h19_1.Draw("HIST")
+    f19_1.Draw("2SAME")
+    f19_2.Draw("2SAME")
+    f19_3.Draw("2SAME")
+    f19_4.Draw("2SAME")
+    h19_1.Draw("HIST SAME")
+    h19_2.Draw("HIST SAME")
+    h19_3.Draw("HIST SAME")
+
+    mark.SetTextAlign(31)
+    mark.SetTextSize(0.065)
+    mark.SetTextFont(61)
+
+    mark.DrawLatex(1.0 - ROOT.gPad.GetRightMargin() - 0.01, 1 - (ROOT.gPad.GetTopMargin() - 0.020), "2018B")
+
+    line1.Draw("SAME")
+    line2.Draw("SAME")
+    line3.Draw("SAME")
+    line4.Draw("SAME")
+    line5.Draw("SAME")
+
+    if args.approved:
+        c1.SaveAs("BinEdgesPlot.pdf")
+    else:
+        c1.SaveAs("BinEdgesPlot_prelim.pdf")
+        c1.SaveAs("BinEdgesPlot_prelim.png")
+
+if __name__ == "__main__" :
+    main()

--- a/Analyzer/test/makeSystBandsLegacyAna.py
+++ b/Analyzer/test/makeSystBandsLegacyAna.py
@@ -1,0 +1,342 @@
+# This script reads in histograms from the analysis framework (specifically for systematically varied ttbar samples)
+# and computes a "total" systematic band for the full background stack and the data/MC ratio.
+# The output files here are intended to be used by plot_1l_LegacyAna.C
+
+import sys, os, ROOT, argparse, math
+from collections import defaultdict
+
+ROOT.TH1.SetDefaultSumw2()
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat("")
+ROOT.gStyle.SetPaintTextFormat("3.2f")
+ROOT.gStyle.SetFrameLineWidth(2)
+ROOT.gStyle.SetEndErrorSize(0)
+
+def doOptions(histo, histoName):
+
+    is1D = "TH1" in histo.ClassName()
+
+    for axis, options in OPTIONSMAP[histoName].iteritems():
+
+        if axis == "X":
+            if "rebin" in options:
+                if is1D: histo.Rebin(options["rebin"])
+                else: histo.RebinX(options["rebin"])
+            if "min" in options and "max" in options: histo.GetXaxis().SetRangeUser(options["min"],options["max"])
+            if "title" in options: histo.GetXaxis().SetTitle(options["title"])
+        if axis == "Y":
+            if "rebin" in options:
+                if is1D: histo.Rebin(options["rebin"])
+                else: histo.RebinY(options["rebin"])
+            if "min" in options and "max" in options: histo.GetYaxis().SetRangeUser(options["min"],options["max"])
+            if "title" in options: histo.GetYaxis().SetTitle(options["title"])
+        if axis == "Z":
+            if "min" in options and "max" in options: histo.GetZaxis().SetRangeUser(options["min"],options["max"])
+
+def getSystematic(nominal, variation, normalize = False):
+
+    nom = nominal.Clone(nominal.GetName()+"_nominalClone"); var = variation.Clone(variation.GetName()+"_variationClone")
+
+    if normalize: nom.Scale(1.0/nom.Integral()); var.Scale(1.0/var.Integral())
+
+    ratio = var.Clone(var.GetName()+"_ratio"); ratioSymm = var.Clone(var.GetName()+"+ratioSymm")
+
+    ratio.Divide(nom)
+
+    for xbin in xrange(1, ratio.GetNbinsX()+1):
+        
+        ratioValAbs = abs(1 - ratio.GetBinContent(xbin))
+        ratio.SetBinContent(xbin, ratioValAbs)
+
+    return ratio
+
+def getFullSystematic(*argv):
+
+    nom = argv[0].Clone(argv[0].GetName()+"_fullSyst")
+    syst = nom.Clone(argv[0].GetName()+"_Syst")
+
+    for xbin in xrange(1, nom.GetNbinsX()+1):
+
+        iVariation = 0
+        for histo in argv[1:]: iVariation += histo.GetBinContent(xbin)**2
+        
+        iVariation = iVariation**0.5
+
+        current = nom.GetBinContent(xbin)
+
+        errBar = current*iVariation
+
+        syst.SetBinContent(xbin, current)
+        syst.SetBinError(xbin, errBar)
+
+    return syst
+
+def getDataMCSyst(data, mc, normalize = False):
+
+    dataMcSyst = mc.Clone("mcSyst")
+
+    scale = 1.0
+    if normalize: scale = data.Integral()/mc.Integral()
+    
+    for xbin in xrange(1, mc.GetNbinsX()+1):
+   
+        datanom = data.GetBinContent(xbin)
+        mcnom  = scale*mc.GetBinContent(xbin)
+        mcVar  = scale*(mcnom + mc.GetBinError(xbin))
+
+        dataMCerr = 0.0
+        if (mcnom == 0 and mcVar != 0) or (mcnom != 0 and mcVar == 0):
+            dataMCerr = 999.0
+        elif mcnom != 0 and mcVar != 0:
+            dataMC = datanom / mcnom
+            dataMCvar = datanom / mcVar
+            dataMCerr = abs(dataMC - dataMCvar)
+
+        dataMcSyst.SetBinContent(xbin, 1)
+        dataMcSyst.SetBinError(xbin, dataMCerr)
+
+    return dataMcSyst
+
+def constructSyst(mc, normUnc = False):
+    mcSyst = mc.Clone(mc.GetName() + "mcstat")
+
+    for xbin in xrange(1, mc.GetNbinsX()+1):
+    
+        count = mc.GetBinContent(xbin)
+        
+        normErr = 0.0
+        if normUnc: normErr = 0.3*count
+
+        err = mc.GetBinError(xbin)
+
+        mcSyst.SetBinContent(xbin, count+err+normErr)
+
+    return mcSyst
+
+def getMCsystBand(normalize, normUnc, dataNom, ttNom, qcdNom, *argv):
+
+    mcSum = 0.0
+    mcSum += ttNom.Integral(); mcSum += qcdNom.Integral()
+    for mcVar in argv: mcSum += mcVar.Integral()
+
+    systBand         = ttNom.Clone("systBand")
+    systBandNoMCstat = ttNom.Clone("systBandNoMCstat")
+
+    scale = 1.0
+    if normalize: scale = dataNom.Integral() / mcSum
+
+    for xbin in xrange(1, systBand.GetNbinsX()+1):
+
+        mcErr = 0.0; mc = 0.0; normErr = 0.0; mcErrNoStat = 0.0
+
+        data = dataNom.GetBinContent(xbin)
+
+        tt    = ttNom.GetBinContent(xbin)
+        mc    += scale*tt
+        ttErr = ttNom.GetBinError(xbin)
+        mcErr += ttErr**2.0; mcErrNoStat += ttErr**2.0
+
+        qcd    = qcdNom.GetBinContent(xbin)
+        mc     += scale*qcd
+        qcdErr = qcdNom.GetBinError(xbin)
+        mcErr  += qcdErr**2.0
+
+        # Only TTX and OTH are left
+        for mcSyst in argv:
+            normErr = 0.0
+            if normUnc: normErr = 0.3*mcSyst.GetBinContent(xbin)
+            mcErr += (mcSyst.GetBinError(xbin)+normErr)**2.0
+            mcErrNoStat += normErr**2.0
+            mc += scale*mcSyst.GetBinContent(xbin)
+ 
+        mcErr = math.sqrt(mcErr); mcErrNoStat = math.sqrt(mcErrNoStat)
+
+        systBand.SetBinContent(xbin, mc);  systBandNoMCstat.SetBinContent(xbin, mc)
+        systBand.SetBinError(xbin, mcErr); systBandNoMCstat.SetBinError(xbin, mcErrNoStat)
+
+    return systBand, systBandNoMCstat
+
+def fixNJetsHisto(histo):
+
+    nbinsX = histo.GetNbinsX()
+    bin12jet = histo.FindBin(12.2)
+    for bin in xrange(bin12jet+1,nbinsX+1):
+    
+        content = histo.GetBinContent(bin)
+        histo.Fill(12.2, content)
+
+        histo.SetBinContent(bin, 0.0)
+        histo.SetBinError(bin, 0.0)
+
+if __name__ == '__main__':
+
+    usage = "usage: %prog [options]"
+    parser = argparse.ArgumentParser(usage)
+    parser.add_argument("--inputDir", dest="inputDir", help="Path to input"         , default="NULL", type=str) 
+    parser.add_argument("--year"    , dest="year"    , help="Which year?"           , default="NULL", type=str) 
+    parser.add_argument("--tag"     , dest="tag"     , help="Unique tag for output" , default="NULL", type=str) 
+    
+    arg = parser.parse_args()
+    
+    OPTIONSMAP = {"h_deepESM" : {"X" : {"rebin" : 10}},
+                  "h_njets" : {"X" : {}},
+                  "h_nb" : {"X" : {}},
+                  "h_mbl" : {"X" : {"rebin" : 10}},
+                  "h_lPt" : {"X" : {"rebin" : 2, "min" : 0, "max" : 1000}},
+                  "h_ht" : {"X" : {"rebin" : 10}},
+                  "h_fixedGridRhoFastjetAll" : {"X" : {"rebin" : 6}},
+                  "fwm2_top6" : {"X" : {"rebin" : 1}},
+                  "fwm3_top6" : {"X" : {"rebin" : 1}},
+                  "fwm4_top6" : {"X" : {"rebin" : 1}},
+                  "jmt_ev0_top6" : {"X" : {"rebin" : 1}},
+                  "jmt_ev1_top6" : {"X" : {"rebin" : 1}},
+                  "jmt_ev2_top6" : {"X" : {"rebin" : 1}}
+    }
+
+    for i in xrange(1, 8):
+        OPTIONSMAP["Jet_cm_pt_%d"%(i)]  = {"X" : {"rebin" : 3}}
+        OPTIONSMAP["Jet_cm_eta_%d"%(i)] = {"X" : {"rebin" : 1}}
+        OPTIONSMAP["Jet_cm_phi_%d"%(i)] = {"X" : {"rebin" : 1}}
+        OPTIONSMAP["Jet_cm_m_%d"%(i)]   = {"X" : {"rebin" : 5}}
+
+    if arg.inputDir == "NULL" or arg.year == "NULL": quit()
+
+    year = arg.year
+    tag = arg.tag
+    INPUTLOC = arg.inputDir + "/%s"%(year)
+       
+    BACKGROUNDS = ["Data", "TT", "QCD", "TTX", "Other"]
+    BACKGROUNDS += ["TT_noHT", "TT_mpTScaled"]
+    BACKGROUNDS += ["TT_isrUp", "TT_isrDown", "TT_fsrUp", "TT_fsrDown"]
+    BACKGROUNDS += ["TT_erdOn", "TT_hdampUp", "TT_hdampDown", "TT_underlyingEvtUp", "TT_underlyingEvtDown"]
+    BACKGROUNDS += ["TT_JECup", "TT_JECdown", "TT_JERup", "TT_JERdown"]
+
+    # Open up all the backgrounds in ROOT
+    BKGDFILES = {}; BKGDHISTOS = {}
+    for bkgd in BACKGROUNDS: BKGDFILES[bkgd] = ROOT.TFile.Open(INPUTLOC + "/%s_%s.root"%(year, bkgd))
+
+    selections = ["_1l_ge7j_ge1b", "_1l_HT300_ge7j_ge1b_Mbl"]
+
+    # Setup a dictionary of histograms for each process
+    for histName in OPTIONSMAP.keys():
+        for bkgd, tfile in BKGDFILES.iteritems():
+            for selection in selections:
+
+                if "h_" != histName[0:2] and selections.index(selection) > 0 or \
+                   "h_" == histName[0:2] and selections.index(selection) == 0: continue
+
+                fullName = histName + selection
+
+                if "noHT" in tfile.GetName():
+                    if "h_" == histName[0:2]: fullName += "_noHTWeight"
+                    else: fullName += "_NoHTweight"
+
+                if "fsrUp"   in tfile.GetName() and "2016" not in tfile.GetName(): fullName += "_fsrUp"
+                if "fsrDown" in tfile.GetName() and "2016" not in tfile.GetName(): fullName += "_fsrDown"
+                if "isrUp"   in tfile.GetName() and "2016" not in tfile.GetName(): fullName += "_isrUp"
+                if "isrDown" in tfile.GetName() and "2016" not in tfile.GetName(): fullName += "_isrDown"
+
+                histo = tfile.Get(fullName); histo.SetDirectory(0)
+
+                histo.SetName(bkgd + "_" + fullName)
+
+                doOptions(histo, histName)
+
+                histo.SetDirectory(0)
+
+                BKGDHISTOS.setdefault(histName + selection, {}).setdefault(bkgd, histo) 
+
+    f = ROOT.TFile.Open("%s/%s_MC_Syst_%s.root"%(INPUTLOC,year,tag),       "RECREATE")
+    g = ROOT.TFile.Open("%s/%s_MC_Ratio_Syst_%s.root"%(INPUTLOC,year,tag), "RECREATE")
+
+    normUnc = False
+    if "wNormUnc" in tag: normUnc = True
+
+    for histName, processDict in BKGDHISTOS.iteritems():
+
+        data                = processDict["Data"]
+        ttNominal           = processDict["TT"]
+        ttnoHT              = processDict["TT_noHT"]
+        ttmpTScaled         = processDict["TT_mpTScaled"]
+
+        tterdOn             = processDict["TT_erdOn"]
+        tthdampUp           = processDict["TT_hdampUp"]
+        tthdampDown         = processDict["TT_hdampDown"]
+        ttunderlyingEvtUp   = processDict["TT_underlyingEvtUp"]
+        ttunderlyingEvtDown = processDict["TT_underlyingEvtDown"]
+
+        ttisrUp             = processDict["TT_isrUp"]
+        ttisrDown           = processDict["TT_isrDown"]
+        ttfsrUp             = processDict["TT_fsrUp"]
+        ttfsrDown           = processDict["TT_fsrDown"]
+
+        ttJECup             = processDict["TT_JECup"]
+        ttJECdown           = processDict["TT_JECdown"]
+        ttJERup             = processDict["TT_JERup"]
+        ttJERdown           = processDict["TT_JERdown"]
+
+        qcd                 = processDict["QCD"]
+        ttx                 = processDict["TTX"]
+        other               = processDict["Other"]
+
+        if "njets" in histName:
+
+            fixNJetsHisto(data)
+            fixNJetsHisto(ttNominal)
+            fixNJetsHisto(ttnoHT)
+            fixNJetsHisto(ttmpTScaled)
+            fixNJetsHisto(qcd)
+            fixNJetsHisto(ttx)
+            fixNJetsHisto(other)
+
+            fixNJetsHisto(tterdOn)           
+            fixNJetsHisto(tthdampUp)         
+            fixNJetsHisto(tthdampDown)       
+            fixNJetsHisto(ttunderlyingEvtUp) 
+            fixNJetsHisto(ttunderlyingEvtDown)
+                               
+            fixNJetsHisto(ttisrUp) 
+            fixNJetsHisto(ttisrDown)
+            fixNJetsHisto(ttfsrUp)
+            fixNJetsHisto(ttfsrDown)
+                               
+            fixNJetsHisto(ttJECup)
+            fixNJetsHisto(ttJECdown)
+            fixNJetsHisto(ttJERup)
+            fixNJetsHisto(ttJERdown)
+
+        mpTScaledSyst         = getSystematic(ttNominal, ttmpTScaled,         normalize=True)
+        noHTSyst              = getSystematic(ttNominal, ttnoHT,              normalize=True)
+
+        erdOnSyst             = getSystematic(ttNominal, tterdOn,             normalize=True)
+        hdampUpSyst           = getSystematic(ttNominal, tthdampUp,           normalize=True)
+        hdampDownSyst         = getSystematic(ttNominal, tthdampDown,         normalize=True)
+        underlyingEvtUpSyst   = getSystematic(ttNominal, ttunderlyingEvtUp,   normalize=True)
+        underlyingEvtDownSyst = getSystematic(ttNominal, ttunderlyingEvtDown, normalize=True)
+
+        isrUpSyst             = getSystematic(ttNominal, ttisrUp,             normalize=True)
+        isrDownSyst           = getSystematic(ttNominal, ttisrDown,           normalize=True)
+        fsrUpSyst             = getSystematic(ttNominal, ttfsrUp,             normalize=True)
+        fsrDownSyst           = getSystematic(ttNominal, ttfsrDown,           normalize=True)
+
+        JECupSyst             = getSystematic(ttNominal, ttJECup,             normalize=True)
+        JECdownSyst           = getSystematic(ttNominal, ttJECdown,           normalize=True)
+        JERupSyst             = getSystematic(ttNominal, ttJERup,             normalize=True)
+        JERdownSyst           = getSystematic(ttNominal, ttJERdown,           normalize=True)
+
+        ttFullVariation    = getFullSystematic(ttNominal, noHTSyst, mpTScaledSyst, erdOnSyst, hdampUpSyst, hdampDownSyst, underlyingEvtUpSyst, underlyingEvtDownSyst, isrUpSyst, isrDownSyst, fsrUpSyst, fsrDownSyst, JECupSyst, JECdownSyst, JERupSyst, JERdownSyst)
+
+        mcSystBand, mcSystBandNoMCstat = getMCsystBand(True, normUnc, data, ttFullVariation, qcd, ttx, other)
+
+        dataMCsyst         = getDataMCSyst(data, mcSystBandNoMCstat, normalize=False)
+
+        f.cd()
+        mcSystBand.SetName(histName)
+        mcSystBand.Write(histName)
+
+        g.cd()
+        dataMCsyst.SetName(histName)
+        dataMCsyst.Write(histName)
+
+    f.Close()
+    g.Close()

--- a/Analyzer/test/njetsStackLegacyAna.py
+++ b/Analyzer/test/njetsStackLegacyAna.py
@@ -1,0 +1,543 @@
+#! /bin/env/python
+
+# This script makes Fig. 5 of the SUS-19-004 paper
+# Inputs are the output from fit diagnostics in Higgs Combine
+
+import ROOT, os, math, array, copy, argparse
+
+ROOT.TH1.AddDirectory(0)
+ROOT.TH1.SetDefaultSumw2()
+ROOT.TH2.SetDefaultSumw2()
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat("")
+ROOT.gStyle.SetPaintTextFormat("3.2f")
+ROOT.gStyle.SetFrameLineWidth(2)
+ROOT.gStyle.SetEndErrorSize(0)
+
+usage = "usage: %prog [options]"
+parser = argparse.ArgumentParser(usage)
+parser.add_argument("--approved", dest="approved", help="Plot is approved",           action="store_true", default=False) 
+parser.add_argument("--sbfit",    dest="sbfit",    help="Results for s+b fit",        action="store_true", default=False)
+parser.add_argument("--inputDir", dest="inputDir", help="Input dir with fit results", type=str,            required=True)
+args = parser.parse_args()
+
+fitStr1 = "fit_b"; fitStr2 = "_bonly"
+if args.sbfit:
+    fitStr1 = "fit_s"
+    fitStr2 = ""
+
+inputDir = args.inputDir
+
+outpath = "./PlotsForPaper/"
+if not os.path.exists(outpath): os.makedirs(outpath)
+
+yearFile = {"2016" : {}, "2017" : {}, "2018pre" : {}, "2018post" : {}}
+
+masses = ["350", "400", "550", "850"]
+
+for year in yearFile.keys():
+    for mass in masses:
+        theFile = "%s/Fit_Data_%s/output-files/RPV_%s_%s/fitDiagnostics%sRPV%s.root"%(inputDir,year,mass,year,year,mass)
+        yearFile[year][mass] = ROOT.TFile.Open(theFile, "READ")
+
+        theFile = "%s/Fit_Data_%s/output-files/SYY_%s_%s/fitDiagnostics%sSYY%s.root"%(inputDir,year,mass,year,year,mass)
+        yearFile[year]["S"+mass] = ROOT.TFile.Open(theFile, "READ")
+
+mvaBins = ["D1", "D2", "D3", "D4"]
+aliases = {"TT"     : "t#bar{t}    ",
+           "QCD"    : "QCD multijet",
+           "TTX"    : "t#bar{t} + X   ",
+           "OTHER"  : "Other   ",
+           "SIG"    : "Fit Signal",
+           "SIG1"   : "RPV m_{ #tilde{t}} = 350 GeV",
+           "SIG2"   : "RPV m_{ #tilde{t}} = 850 GeV",
+           "SIG3"   : "Stealth SYY m_{ #tilde{t}} = 350 GeV",
+           "SIG4"   : "Stealth SYY m_{ #tilde{t}} = 850 GeV"
+     
+}
+
+procDictionary = {
+                   "TTX"   : {"graph" : 0, "h" : 0, "lstyle" : 0, "lsize" : 0, "msize" : 0, "color" : ROOT.kOrange+2},
+                   "QCD"   : {"graph" : 0, "h" : 0, "lstyle" : 0, "lsize" : 0, "msize" : 0, "color" : ROOT.kGreen+1},
+                   "OTHER" : {"graph" : 0, "h" : 0, "lstyle" : 0, "lsize" : 0, "msize" : 0, "color" : ROOT.kMagenta+2},
+                   "TT"    : {"graph" : 0, "h" : 0, "lstyle" : 0, "lsize" : 0, "msize" : 0, "color" : ROOT.kBlue-6},
+                   "DATA"  : {"graph" : 0, "h" : 0, "lstyle" : 0, "lsize" : 5, "msize" : 5, "color" : ROOT.kBlack},
+                   "SYST"  : {"graph" : 0, "h" : 0, "lstyle" : 0, "lsize" : 0, "msize" : 0, "color" : ROOT.kBlack},
+                   "SIG"   : {"graph" : 0, "h" : 0, "lstyle" : 0, "lsize" : 0, "msize" : 0, "color" : ROOT.kGray+1},
+                   "SIG1"  : {"graph" : 0, "h" : 0, "lstyle" : 2, "lsize" : 4, "msize" : 0, "color" : ROOT.kMagenta},
+                   "SIG2"  : {"graph" : 0, "h" : 0, "lstyle" : 3, "lsize" : 4, "msize" : 0, "color" : ROOT.kRed},
+                   "SIG3"  : {"graph" : 0, "h" : 0, "lstyle" : 1, "lsize" : 4, "msize" : 0, "color" : ROOT.kCyan+1},
+                   "SIG4"  : {"graph" : 0, "h" : 0, "lstyle" : 4, "lsize" : 4, "msize" : 0, "color" : ROOT.kBlue}
+}
+
+mvaDictionary = {"D1" : copy.deepcopy(procDictionary),
+                 "D2" : copy.deepcopy(procDictionary),
+                 "D3" : copy.deepcopy(procDictionary),
+                 "D4" : copy.deepcopy(procDictionary)
+}
+
+theDictionary = {"2016"     : copy.deepcopy(mvaDictionary),
+                 "2017"     : copy.deepcopy(mvaDictionary),
+                 "2018pre"  : copy.deepcopy(mvaDictionary),
+                 "2018post" : copy.deepcopy(mvaDictionary)
+}
+
+perMVADictionary = {"D1" : copy.deepcopy(procDictionary),
+                    "D2" : copy.deepcopy(procDictionary),
+                    "D3" : copy.deepcopy(procDictionary),
+                    "D4" : copy.deepcopy(procDictionary)
+}
+
+run2Dictionary = copy.deepcopy(procDictionary)
+
+for year, mvaDict in theDictionary.iteritems():
+
+    for mva, procDict in mvaDict.iteritems(): 
+
+        for process, d in procDict.iteritems():
+
+            if   process == "SIG1":
+                path = "shapes_prefit/%s/total_signal"%(mva)
+
+                d["h"] = yearFile[year]["350"].Get(path); d["h"].SetDirectory(0); d["h"].SetName("%s_%s_RPV350"%(year,mva))
+
+            elif process == "SIG2":
+                path = "shapes_prefit/%s/total_signal"%(mva)
+
+                d["h"] = yearFile[year]["850"].Get(path); d["h"].SetDirectory(0); d["h"].SetName("%s_%s_RPV850"%(year,mva))
+
+            elif process == "SIG3":
+                 path = "shapes_prefit/%s/total_signal"%(mva)
+
+                 d["h"] = yearFile[year]["S350"].Get(path); d["h"].SetDirectory(0); d["h"].SetName("%s_%s_SYY350"%(year,mva))
+       
+            elif process == "SIG4":
+                 path = "shapes_prefit/%s/total_signal"%(mva)
+
+                 d["h"] = yearFile[year]["S850"].Get(path); d["h"].SetDirectory(0); d["h"].SetName("%s_%s_SYY850"%(year,mva))
+
+            elif process == "SYST":
+    
+                rooPlot = yearFile[year]["350"].Get("%s_CMS_th1x_%s"%(mva,fitStr1))
+                rooCurveErr = rooPlot.getCurve("pdf_bin%s%s_Norm[CMS_th1x]_errorband"%(mva,fitStr2))
+                rooCurveVal = rooPlot.getCurve("pdf_bin%s%s_Norm[CMS_th1x]"%(mva,fitStr2))
+                
+                xband = rooCurveErr.GetX(); yband = rooCurveErr.GetY(); npband = rooCurveErr.GetN()
+                x = rooCurveVal.GetX(); y = rooCurveVal.GetY(); np = rooCurveVal.GetN()
+                yErrUp = array.array('d', [0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+                yErrDown = array.array('d', [0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+                xErr = array.array('d', [0.5, 0.5, 0.5, 0.5, 0.5, 0.5])
+                hx = array.array('d', [0.5, 1.5, 2.5, 3.5, 4.5, 5.5])
+                hy = array.array('d', [0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+                
+                bins = [0.5, 1.5, 2.5, 3.5, 4.5, 5.5] 
+                for i in bins:
+                    idx = bins.index(i)
+                    out = False
+                    for aX in xrange(0,npband/2):
+                        if out: break
+                        for bX in xrange(0, np):
+                            if x[bX] == i and xband[aX] == i:
+                                yErrUp[idx] = yband[aX] - y[bX]
+                                hy[idx] = y[bX]
+                                out = True
+                                break
+                
+                for i in bins:
+                    idx = bins.index(i)
+                    out = False
+                    for aX in xrange(npband/2,npband):
+                        if out: break
+                        for bX in xrange(0,np):
+                            if x[bX] == i and xband[aX] == i:
+                                yErrDown[idx] = y[bX]-yband[aX]
+                                out = True
+                                break
+                       
+                d["graph"] = ROOT.TGraphAsymmErrors(6, hx, hy, xErr, xErr, yErrDown, yErrUp)
+
+            elif process == "DATA":
+    
+                rooPlot = yearFile[year]["350"].Get("%s_CMS_th1x_fit_b"%(mva))
+                rooHist = rooPlot.getHist("h_%s"%(mva))
+    
+                x = rooHist.GetX()
+                y = rooHist.GetY()
+                xErr = array.array('d', [0.5, 0.5, 0.5, 0.5, 0.5, 0.5])
+                yErr = array.array('d', [math.sqrt(i) for i in y])
+    
+                d["graph"] = ROOT.TGraphAsymmErrors(6, x, y, xErr, xErr, yErr, yErr)
+    
+                d["h"] = ROOT.TH1F("%s_%s_data"%(year,mva), "%s_%s_data"%(year,mva), 6, 0, 6)
+                d["h"].SetDirectory(0)
+                x = ROOT.Double(0.0); y = ROOT.Double(0.0)
+                for iP in xrange(0,d["graph"].GetN()):
+                    
+                    theBin = d["h"].GetXaxis().FindBin(iP)
+    
+                    d["graph"].GetPoint(iP, x, y)
+                    
+                    d["h"].Fill(x,y)
+                    d["h"].SetBinError(theBin, math.sqrt(y))
+
+            else:
+                path = "shapes_%s/%s/%s"%(fitStr1,mva,process)
+
+                d["h"] = yearFile[year]["400"].Get(path); d["h"].SetDirectory(0); d["h"].SetName("%s_%s_%s"%(year,mva,process)); d["h"].Sumw2()
+    
+
+for year, d in yearFile.iteritems():
+    for mass, f in d.iteritems():
+        f.Close()
+
+for mva in mvaBins:
+    for process in ["TTX", "OTHER", "QCD", "TT", "DATA", "SYST", "SIG", "SIG1", "SIG2", "SIG3", "SIG4"]:
+        for year in ["2016", "2017", "2018pre", "2018post"]:
+
+            histo = "h"
+            if process == "SYST": histo = "graph"
+
+            if perMVADictionary[mva][process][histo] == 0: perMVADictionary[mva][process][histo] = theDictionary[year][mva][process][histo].Clone("perMVA_%s_%s_clone"%(mva,process))
+        
+            else:
+                if process == "SYST":
+
+                    xOld = ROOT.Double(0.0); yOld = ROOT.Double(0.0)
+                    xNew = ROOT.Double(0.0); yNew = ROOT.Double(0.0)
+                    for i in xrange(0, theDictionary[year][mva][process][histo].GetN()):
+
+                        perMVADictionary[mva][process][histo].GetPoint(i,xOld,yOld)
+                        theDictionary[year][mva][process][histo].GetPoint(i,xNew,yNew)
+
+                        oldUpErr = perMVADictionary[mva][process][histo].GetErrorYhigh(i)
+                        oldDownErr = perMVADictionary[mva][process][histo].GetErrorYlow(i)
+
+                        newUpErr = theDictionary[year][mva][process][histo].GetErrorYhigh(i)
+                        newDownErr = theDictionary[year][mva][process][histo].GetErrorYlow(i)
+
+                        perMVADictionary[mva][process][histo].SetPoint(i,xNew,yNew+yOld)
+
+                        perMVADictionary[mva][process][histo].SetPointEYhigh(i,(oldUpErr**2.0+newUpErr**2.0)**0.5)
+                        perMVADictionary[mva][process][histo].SetPointEYlow(i,(oldDownErr**2.0+newDownErr**2.0)**0.5)
+    
+                else: perMVADictionary[mva][process][histo].Add(theDictionary[year][mva][process][histo])
+
+            if run2Dictionary[process][histo] == 0: run2Dictionary[process][histo] = theDictionary[year][mva][process][histo].Clone("run2_%s_%s_clone"%(mva,process))
+            else:
+                if process == "SYST":
+
+                    xOld = ROOT.Double(0.0); yOld = ROOT.Double(0.0)
+                    xNew = ROOT.Double(0.0); yNew = ROOT.Double(0.0)
+                    for i in xrange(0, theDictionary[year][mva][process][histo].GetN()):
+                    
+                        run2Dictionary[process][histo].GetPoint(i,xOld,yOld)
+                        theDictionary[year][mva][process][histo].GetPoint(i,xNew,yNew)
+
+                        oldUpErr = run2Dictionary[process][histo].GetErrorYhigh(i)
+                        oldDownErr = run2Dictionary[process][histo].GetErrorYlow(i)
+
+                        newUpErr = theDictionary[year][mva][process][histo].GetErrorYhigh(i)
+                        newDownErr = theDictionary[year][mva][process][histo].GetErrorYlow(i)
+
+                        run2Dictionary[process][histo].SetPoint(i,xNew,yNew+yOld)
+                        run2Dictionary[process][histo].SetPointEYhigh(i,(oldUpErr**2.0+newUpErr**2.0)**0.5)
+                        run2Dictionary[process][histo].SetPointEYlow(i,(oldDownErr**2.0+newDownErr**2.0)**0.5)
+    
+                else: run2Dictionary[process][histo].Add(theDictionary[year][mva][process][histo])
+
+            if (process != "DATA" and process != "SYST" and "SIG" not in process) or process == "SIG": run2Dictionary[process][histo].SetFillColor(theDictionary[year][mva][process]["color"])
+            if process == "SYST":
+                run2Dictionary[process][histo].SetFillStyle(3004)
+                run2Dictionary[process][histo].SetFillColor(ROOT.kBlack)
+
+            run2Dictionary[process][histo].SetMarkerColor(theDictionary[year][mva][process]["color"])
+            run2Dictionary[process][histo].SetLineColor(theDictionary[year][mva][process]["color"])
+    
+            run2Dictionary[process][histo].SetMarkerSize(theDictionary[year][mva][process]["msize"])
+            run2Dictionary[process][histo].SetMarkerStyle(20)
+            run2Dictionary[process][histo].SetLineWidth(theDictionary[year][mva][process]["lsize"])
+            if "SIG" in process: run2Dictionary[process][histo].SetLineStyle(theDictionary[year][mva][process]["lstyle"])
+
+            if (process != "DATA" and process != "SYST" and "SIG" not in process) or process == "SIG": perMVADictionary[mva][process][histo].SetFillColor(theDictionary[year][mva][process]["color"])
+            if process == "SYST":
+                perMVADictionary[mva][process][histo].SetFillStyle(3004)
+                perMVADictionary[mva][process][histo].SetFillColor(ROOT.kBlack)
+
+            perMVADictionary[mva][process][histo].SetMarkerColor(theDictionary[year][mva][process]["color"])
+            perMVADictionary[mva][process][histo].SetLineColor(theDictionary[year][mva][process]["color"])
+    
+            perMVADictionary[mva][process][histo].SetMarkerSize(theDictionary[year][mva][process]["msize"])
+            perMVADictionary[mva][process][histo].SetMarkerStyle(20)
+            perMVADictionary[mva][process][histo].SetLineWidth(theDictionary[year][mva][process]["lsize"])
+            if "SIG" in process: perMVADictionary[mva][process][histo].SetLineStyle(theDictionary[year][mva][process]["lstyle"])
+
+for mva in mvaBins:
+
+    c = ROOT.TCanvas("%s_c"%(mva), "%s_c"%(mva), 2400, 2400)
+    totalBkgd = ROOT.TH1F("%s_totalBkgd"%(mva), "%s_totalBkgd"%(mva), 6, 0, 6)
+    totalRatio = ROOT.TH1F("%s_totalRatio"%(mva), "%s_totalRatio"%(mva), 6, 0, 6)
+    theStack = ROOT.THStack("%s_bkgd_stack"%(mva), "%s_bkgd_stack"%(mva))
+
+    systRatio = perMVADictionary[mva]["SYST"]["graph"].Clone("%s_ratioSyst_clone"%(mva))
+
+    for process in ["SIG", "TTX", "OTHER", "QCD", "TT"]:
+        totalBkgd.Add(perMVADictionary[mva][process]["h"])
+        theStack.Add(perMVADictionary[mva][process]["h"])
+
+    mcy = ROOT.Double(0.0)
+    datax = ROOT.Double(0.0); datay = ROOT.Double(0.0)
+    yErrUp = ROOT.Double(0.0); yErrDown = ROOT.Double(0.0)
+    for i in xrange(0, systRatio.GetN()):
+
+        mcy = totalBkgd.GetBinContent(i+1)
+
+        perMVADictionary[mva]["SYST"]["graph"].GetPoint(i, datax, datay)
+        yErrUp = perMVADictionary[mva]["SYST"]["graph"].GetErrorYhigh(i)
+        yErrDown = perMVADictionary[mva]["SYST"]["graph"].GetErrorYlow(i)
+
+        systRatio.SetPoint(i, datax, 0.0)
+        systRatio.SetPointEYhigh(i, yErrUp/datay**0.5)
+        systRatio.SetPointEYlow(i, yErrDown/datay**0.5)
+      
+    for xbin in xrange(1, totalBkgd.GetNbinsX()+1):
+        totalRatio.SetBinContent(xbin, (perMVADictionary[mva]["DATA"]["h"].GetBinContent(xbin)-totalBkgd.GetBinContent(xbin))/perMVADictionary[mva]["DATA"]["h"].GetBinContent(xbin)**0.5)
+        totalRatio.SetBinError(xbin, 1.0)
+    
+    XMin = 0;    XMax = 1; RatioXMin = 0; RatioXMax = 1 
+    YMin = 0.30; YMax = 1; RatioYMin = 0; RatioYMax = 0.30
+    PadFactor = (YMax-YMin) / (RatioYMax-RatioYMin)
+    c.Divide(1,2); c.cd(1); ROOT.gPad.SetLogy(); ROOT.gPad.SetLogz(); ROOT.gPad.SetPad(XMin, YMin, XMax, YMax)
+    
+    ROOT.gPad.SetTopMargin(0.10)
+    ROOT.gPad.SetLeftMargin(0.15)
+    ROOT.gPad.SetBottomMargin(0.00)
+    ROOT.gPad.SetRightMargin(0.04)
+    
+    iamLegend = ROOT.TLegend(ROOT.gPad.GetLeftMargin() + 0.02, 0.70 - ROOT.gPad.GetTopMargin(), ROOT.gPad.GetLeftMargin() + 0.47, 1 - ROOT.gPad.GetTopMargin() - 0.02)
+    
+    iamLegend.SetTextSize(0.045)
+    iamLegend.SetNColumns(2)
+    iamLegend.SetBorderSize(2)
+    
+    sigLegend = ROOT.TLegend(ROOT.gPad.GetLeftMargin() + 0.50, 0.70 - ROOT.gPad.GetTopMargin(), 1. - ROOT.gPad.GetRightMargin() - 0.05, 1 - ROOT.gPad.GetTopMargin() - 0.02)
+    sigLegend.SetTextSize(0.045)
+    sigLegend.SetNColumns(1)
+    sigLegend.SetBorderSize(2)
+
+    for process in ["TTX", "OTHER", "QCD", "TT"]: iamLegend.AddEntry(perMVADictionary[mva][process]["h"], aliases[process], "F")
+    for process in ["SIG1", "SIG2", "SIG3", "SIG4"]: sigLegend.AddEntry(perMVADictionary[mva][process]["h"], aliases[process], "L")
+
+    iamLegend.AddEntry(perMVADictionary[mva]["DATA"]["h"], "Data", "EP")
+
+    dummy1 = ROOT.TH1F("dummy1_%s"%(mva), "dummy1_%s"%(mva), 6, 0, 6)
+    dummy1.SetTitle("")
+    dummy1.GetYaxis().SetTitle("Events / bin")
+    dummy1.GetYaxis().SetTitleSize(0.07)
+    dummy1.GetXaxis().SetTitleSize(0.07)
+    dummy1.GetYaxis().SetLabelSize(0.06)
+    dummy1.GetXaxis().SetLabelSize(0.06)
+    dummy1.GetYaxis().SetTitleOffset(1.1)
+    dummy1.GetXaxis().SetTitleOffset(2.1)
+    dummy1.SetMaximum(1e8)
+    dummy1.SetMinimum(0.5)
+
+    dummy1.Draw()
+    theStack.Draw("SAME")
+    perMVADictionary[mva]["DATA"]["h"].Draw("E0P SAME")
+    perMVADictionary[mva]["SYST"]["graph"].Draw("2SAME")
+    perMVADictionary[mva]["SIG1"]["h"].Draw("SAME")
+    perMVADictionary[mva]["SIG2"]["h"].Draw("SAME")
+    perMVADictionary[mva]["SIG3"]["h"].Draw("SAME")
+    perMVADictionary[mva]["SIG4"]["h"].Draw("SAME")
+
+    iamLegend.Draw("SAME")
+    sigLegend.Draw("SAME")
+
+    mark = ROOT.TLatex()
+    mark.SetNDC(True)
+
+    mark.SetTextAlign(11);
+    mark.SetTextSize(0.065);
+    mark.SetTextFont(61);
+    mark.DrawLatex(ROOT.gPad.GetLeftMargin(), 1 - (ROOT.gPad.GetTopMargin() - 0.02), "CMS")
+    mark.SetTextFont(52);
+    if not args.approved: mark.DrawLatex(ROOT.gPad.GetLeftMargin() + 0.103, 1 - (ROOT.gPad.GetTopMargin() - 0.02), "Preliminary")
+
+    mark.SetTextFont(42)
+    mark.SetTextAlign(31)
+    mark.DrawLatex(1 - ROOT.gPad.GetRightMargin(), 1 - (ROOT.gPad.GetTopMargin() - 0.02), "137.2 fb^{-1} (13 TeV)")
+   
+    mark2 = ROOT.TLatex()
+    mark2.SetNDC(True)
+    mark.SetTextAlign(11)
+    mark.SetTextSize(0.065)
+    mark.SetTextFont(62)
+    mark.DrawLatex(ROOT.gPad.GetLeftMargin() + 0.60, 0.65 - ROOT.gPad.GetTopMargin(), "S_{NN,%s}"%(mva[-1]))
+
+    c.cd(2)
+    
+    ROOT.gPad.SetGridy()
+    ROOT.gPad.SetTopMargin(0.00)
+    ROOT.gPad.SetBottomMargin(0.35)
+    ROOT.gPad.SetRightMargin(0.04)
+    ROOT.gPad.SetLeftMargin(0.15)
+    ROOT.gPad.SetPad(RatioXMin, RatioYMin, RatioXMax, RatioYMax)
+    
+    for i in xrange(1, totalRatio.GetNbinsX()+1):
+        if i != totalRatio.GetNbinsX(): totalRatio.GetXaxis().SetBinLabel(i, str(i+6))
+        else:                           totalRatio.GetXaxis().SetBinLabel(i, "#geq %s"%(str(i+6)))
+
+    totalRatio.GetYaxis().SetRangeUser(-1.09, 1.09)
+    totalRatio.SetTitle("")
+    totalRatio.GetXaxis().SetTitle("Number of jets")
+    totalRatio.GetYaxis().SetNdivisions(5, 5, 0)
+    totalRatio.GetYaxis().SetTitle("Data / Pred.")
+    totalRatio.GetYaxis().SetTitleSize(dummy1.GetYaxis().GetTitleSize()*PadFactor)
+    totalRatio.GetXaxis().SetTitleSize(dummy1.GetXaxis().GetTitleSize()*PadFactor)
+    totalRatio.GetYaxis().SetLabelSize(dummy1.GetYaxis().GetLabelSize()*PadFactor)
+    totalRatio.GetXaxis().SetLabelSize(1.5*dummy1.GetXaxis().GetLabelSize()*PadFactor)
+    totalRatio.GetYaxis().SetTitleOffset(0.8*dummy1.GetYaxis().GetTitleOffset()/PadFactor)
+    totalRatio.GetXaxis().SetTitleOffset(dummy1.GetXaxis().GetTitleOffset()/PadFactor)
+    totalRatio.GetXaxis().SetLabelOffset(0.02)
+    totalRatio.SetMarkerStyle(20); totalRatio.SetMarkerSize(5); totalRatio.SetMarkerColor(ROOT.kBlack);
+    totalRatio.SetLineWidth(5); totalRatio.SetLineColor(ROOT.kBlack)
+    
+    totalRatio.Draw("E0P")
+    systRatio.Draw("2SAME")
+    
+    if args.approved:
+        c.SaveAs("%s/%s_njets_DataVsMC_%s.pdf"%(outpath,mva,fitStr1))
+    else:
+        c.SaveAs("%s/%s_njets_DataVsMC_%s_prelim.pdf"%(outpath,mva,fitStr1))
+
+cAll = ROOT.TCanvas("c", "c", 2400, 2400)
+totalBkgdAll = ROOT.TH1F("totalBkgdAll", "totalBkgdAll", 6, 0, 6)
+totalDataAll = ROOT.TH1F("totalDataAll", "totalDataAll", 6, 0, 6)
+totalRatioAll = ROOT.TH1F("totalRatioAll", "totalRatioAll", 6, 0, 6)
+theStackAll = ROOT.THStack("theStackAll", "theStackAll")
+
+systRatioAll = run2Dictionary["SYST"]["graph"].Clone("%s_ratioSyst_clone"%(mva))
+
+for process in ["SIG", "TTX", "OTHER", "QCD", "TT"]:
+    totalBkgdAll.Add(run2Dictionary[process]["h"])
+    theStackAll.Add(run2Dictionary[process]["h"])
+
+for process in ["SIG1", "SIG2", "SIG3", "SIG4"]:
+    sigLegend.AddEntry(run2Dictionary[process]["h"], aliases[process], "L")
+
+mcy = ROOT.Double(0.0)
+datax = ROOT.Double(0.0); datay = ROOT.Double(0.0)
+yErrUp = ROOT.Double(0.0); yErrDown = ROOT.Double(0.0)
+for i in xrange(0, systRatioAll.GetN()):
+
+    mcy = totalBkgdAll.GetBinContent(i+1)
+
+    run2Dictionary["SYST"]["graph"].GetPoint(i, datax, datay)
+    yErrUp = run2Dictionary["SYST"]["graph"].GetErrorYhigh(i)
+    yErrDown = run2Dictionary["SYST"]["graph"].GetErrorYlow(i)
+
+    systRatioAll.SetPoint(i, datax, 1.0)
+    systRatioAll.SetPointEYhigh(i, datay/mcy - datay/(mcy+yErrUp))
+    systRatioAll.SetPointEYlow(i, datay/(mcy-yErrDown) - datay/mcy)
+
+totalRatioAll.Divide(run2Dictionary["DATA"]["h"],totalBkgdAll)    
+
+XMin = 0;    XMax = 1; RatioXMin = 0; RatioXMax = 1 
+YMin = 0.30; YMax = 1; RatioYMin = 0; RatioYMax = 0.30
+PadFactor = (YMax-YMin) / (RatioYMax-RatioYMin)
+cAll.Divide(1,2); cAll.cd(1); ROOT.gPad.SetLogy(); ROOT.gPad.SetLogz(); ROOT.gPad.SetPad(XMin, YMin, XMax, YMax)
+
+ROOT.gPad.SetTopMargin(0.10)
+ROOT.gPad.SetLeftMargin(0.15)
+ROOT.gPad.SetBottomMargin(0.00)
+ROOT.gPad.SetRightMargin(0.04)
+
+iamLegend = ROOT.TLegend(ROOT.gPad.GetLeftMargin() + 0.02, 0.85 - ROOT.gPad.GetTopMargin(), ROOT.gPad.GetLeftMargin() + 0.8, 1 - ROOT.gPad.GetTopMargin() - 0.02)
+
+iamLegend.SetTextSize(0.040)
+iamLegend.SetNColumns(5)
+iamLegend.SetBorderSize(2)
+
+sigLegend = ROOT.TLegend(ROOT.gPad.GetLeftMargin() + 0.02, 0.75 - ROOT.gPad.GetTopMargin(), 1. - ROOT.gPad.GetRightMargin() - 0.02, 0.85 - ROOT.gPad.GetTopMargin())
+sigLegend.SetTextSize(0.040)
+sigLegend.SetNColumns(2)
+sigLegend.SetBorderSize(2)
+
+for process in ["TT", "TTX", "OTHER", "QCD"]: iamLegend.AddEntry(run2Dictionary[process]["h"], aliases[process], "F") 
+for process in ["SIG1", "SIG3", "SIG2", "SIG4"]: sigLegend.AddEntry(run2Dictionary[process]["h"], aliases[process], "L")
+
+iamLegend.AddEntry(run2Dictionary["DATA"]["h"], "Data", "EP")
+
+dummy1 = ROOT.TH1F("dummy1", "dummy1", 6, 0, 6)
+dummy1.SetTitle("")
+dummy1.GetYaxis().SetTitle("Events / bin")
+dummy1.GetYaxis().SetTitleSize(0.07)
+dummy1.GetXaxis().SetTitleSize(0.07)
+dummy1.GetYaxis().SetLabelSize(0.06)
+dummy1.GetXaxis().SetLabelSize(0.06)
+dummy1.GetYaxis().SetTitleOffset(1.1)
+dummy1.GetXaxis().SetTitleOffset(2.1)
+dummy1.SetMaximum(2e8)
+dummy1.SetMinimum(5)
+
+dummy1.Draw()
+theStackAll.Draw("SAME")
+run2Dictionary["DATA"]["h"].Draw("E0P SAME")
+run2Dictionary["SYST"]["graph"].Draw("2SAME")
+run2Dictionary["SIG1"]["h"].Draw("SAME")
+run2Dictionary["SIG2"]["h"].Draw("SAME")
+run2Dictionary["SIG3"]["h"].Draw("SAME")
+run2Dictionary["SIG4"]["h"].Draw("SAME")
+
+iamLegend.Draw("SAME")
+sigLegend.Draw("SAME")
+
+mark = ROOT.TLatex()
+mark.SetNDC(True)
+
+mark.SetTextAlign(11);
+mark.SetTextSize(0.065);
+mark.SetTextFont(61);
+mark.DrawLatex(ROOT.gPad.GetLeftMargin(), 1 - (ROOT.gPad.GetTopMargin() - 0.02), "CMS")
+mark.SetTextFont(52);
+if not args.approved: mark.DrawLatex(ROOT.gPad.GetLeftMargin() + 0.103, 1 - (ROOT.gPad.GetTopMargin() - 0.02), "Preliminary")
+
+mark.SetTextFont(42)
+mark.SetTextAlign(31)
+mark.DrawLatex(1 - ROOT.gPad.GetRightMargin(), 1 - (ROOT.gPad.GetTopMargin() - 0.02), "137 fb^{-1} (13 TeV)")
+
+cAll.cd(2)
+
+ROOT.gPad.SetGridy()
+ROOT.gPad.SetTopMargin(0.00)
+ROOT.gPad.SetBottomMargin(0.35)
+ROOT.gPad.SetRightMargin(0.04)
+ROOT.gPad.SetLeftMargin(0.15)
+ROOT.gPad.SetPad(RatioXMin, RatioYMin, RatioXMax, RatioYMax)
+
+for i in xrange(1, totalRatioAll.GetNbinsX()+1):
+    if i != totalRatioAll.GetNbinsX(): totalRatioAll.GetXaxis().SetBinLabel(i, str(i+6))
+    else:                           totalRatioAll.GetXaxis().SetBinLabel(i, "#geq %s"%(str(i+6)))
+
+totalRatioAll.GetYaxis().SetRangeUser(0.91,1.09)
+totalRatioAll.SetTitle("")
+totalRatioAll.GetXaxis().SetTitle("Number of jets")
+totalRatioAll.GetYaxis().SetNdivisions(5, 5, 0)
+totalRatioAll.GetYaxis().SetTitle("Data / Pred.")
+totalRatioAll.GetYaxis().SetTitleSize(dummy1.GetYaxis().GetTitleSize()*PadFactor)
+totalRatioAll.GetXaxis().SetTitleSize(dummy1.GetXaxis().GetTitleSize()*PadFactor)
+totalRatioAll.GetYaxis().SetLabelSize(dummy1.GetYaxis().GetLabelSize()*PadFactor)
+totalRatioAll.GetXaxis().SetLabelSize(1.5*dummy1.GetXaxis().GetLabelSize()*PadFactor)
+totalRatioAll.GetYaxis().SetTitleOffset(1.0*dummy1.GetYaxis().GetTitleOffset()/PadFactor)
+totalRatioAll.GetXaxis().SetTitleOffset(dummy1.GetXaxis().GetTitleOffset()/PadFactor)
+totalRatioAll.GetXaxis().SetLabelOffset(0.02)
+totalRatioAll.SetMarkerStyle(20); totalRatioAll.SetMarkerSize(5); totalRatioAll.SetMarkerColor(ROOT.kBlack);
+totalRatioAll.SetLineWidth(5); totalRatioAll.SetLineColor(ROOT.kBlack)
+
+totalRatioAll.Draw("E0P")
+systRatioAll.Draw("2SAME")
+
+if args.approved:
+    cAll.SaveAs("%s/njets_DataVsMC_%s.pdf"%(outpath,fitStr1))
+else:
+    cAll.SaveAs("%s/njets_DataVsMC_%s_prelim.pdf"%(outpath,fitStr1))

--- a/Analyzer/test/plot_1l_LegacyAna.C
+++ b/Analyzer/test/plot_1l_LegacyAna.C
@@ -13,7 +13,7 @@ public:
     std::string plotName_;
 };
 
-void setHistInfo(const std::string& path, std::vector<histInfo>& data, std::vector<histInfo>& bg, std::vector<histInfo>& sig, std::vector<histInfo>& syst, std::vector<histInfo>& rsyst, const std::string& year, const bool doQCD = false)
+void setHistInfo(const std::string& path, std::vector<histInfo>& data, std::vector<histInfo>& bg, std::vector<histInfo>& sig, std::vector<histInfo>& syst, std::vector<histInfo>& rsyst, const std::string& year, const bool supplementary = false, const bool doQCD = false)
 {
     //entry for data
     //this uses the initializer syntax to initialize the histInfo object
@@ -38,27 +38,30 @@ void setHistInfo(const std::string& path, std::vector<histInfo>& data, std::vect
         };
     }
 
-    //sig = {        
-    //    {"RPV m_{#tilde{t}} = 350 GeV (#sigma_{#tilde{t} #bar{#tilde{t}}} #times 4)", path + "/"+year+"_RPV_2t6j_mStop-350.root",  "hist", kMagenta, printNEvents, 4.0, false, 2},
-    //    {"RPV m_{#tilde{t}} = 850 GeV (#sigma_{#tilde{t} #bar{#tilde{t}}} #times 16)", path + "/"+year+"_RPV_2t6j_mStop-850.root",  "hist", kRed   , printNEvents, 16.0, false, 3},
-    //    {"Stealth SYY m_{#tilde{t}} = 350 GeV (#sigma_{#tilde{t} #bar{#tilde{t}}} #times 4)", path + "/"+year+"_StealthSYY_2t6j_mStop-350.root",  "hist", kCyan + 1, printNEvents, 4.0, false, 1},        
-    //    {"Stealth SYY m_{#tilde{t}} = 850 GeV (#sigma_{#tilde{t} #bar{#tilde{t}}} #times 16)", path + "/"+year+"_StealthSYY_2t6j_mStop-850.root",  "hist", kBlue, printNEvents, 16.0, false, 4},        
-    //};
-
-    sig = {        
-        {"RPV m_{#tilde{t}} = 350 GeV)",         path + "/"+year+"_RPV_2t6j_mStop-350.root",        "hist", kMagenta,  1.0, false, 2},
-        {"RPV m_{#tilde{t}} = 850 GeV)",         path + "/"+year+"_RPV_2t6j_mStop-850.root",        "hist", kRed,      1.0, false, 3},
-        {"Stealth SYY m_{#tilde{t}} = 350 GeV)", path + "/"+year+"_StealthSYY_2t6j_mStop-350.root", "hist", kCyan + 1, 1.0, false, 1},        
-        {"Stealth SYY m_{#tilde{t}} = 850 GeV)", path + "/"+year+"_StealthSYY_2t6j_mStop-850.root", "hist", kBlue,     1.0, false, 4},        
-    };
+    if (not supplementary)
+    {
+        sig = {        
+            {"RPV m_{#tilde{t}} = 350 GeV (#sigma_{#tilde{t} #bar{#tilde{t}}} #times 4)",          path + "/"+year+"_RPV_2t6j_mStop-350.root",        "hist", kMagenta,  4.0,  false, 2},
+            {"RPV m_{#tilde{t}} = 850 GeV (#sigma_{#tilde{t} #bar{#tilde{t}}} #times 16)",         path + "/"+year+"_RPV_2t6j_mStop-850.root",        "hist", kRed   ,   16.0, false, 3},
+            {"Stealth SYY m_{#tilde{t}} = 350 GeV (#sigma_{#tilde{t} #bar{#tilde{t}}} #times 4)",  path + "/"+year+"_StealthSYY_2t6j_mStop-350.root", "hist", kCyan + 1, 4.0,  false, 1},        
+            {"Stealth SYY m_{#tilde{t}} = 850 GeV (#sigma_{#tilde{t} #bar{#tilde{t}}} #times 16)", path + "/"+year+"_StealthSYY_2t6j_mStop-850.root", "hist", kBlue,     16.0, false, 4},        
+        };
+    } else {
+        sig = {        
+            {"RPV m_{#tilde{t}} = 350 GeV",         path + "/"+year+"_RPV_2t6j_mStop-350.root",        "hist", kMagenta,  1.0, false, 2},
+            {"RPV m_{#tilde{t}} = 850 GeV",         path + "/"+year+"_RPV_2t6j_mStop-850.root",        "hist", kRed,      1.0, false, 3},
+            {"Stealth SYY m_{#tilde{t}} = 350 GeV", path + "/"+year+"_StealthSYY_2t6j_mStop-350.root", "hist", kCyan + 1, 1.0, false, 1},        
+            {"Stealth SYY m_{#tilde{t}} = 850 GeV", path + "/"+year+"_StealthSYY_2t6j_mStop-850.root", "hist", kBlue,     1.0, false, 4},        
+        };
+    }
 
     if (!doQCD) {
         syst = {
-            {"SYST",   path + "/"+year+"_MC_Syst_wNormUncJan08.root", "hist", kBlack, 1.0, true, 0},
+            {"SYST",   path + "/"+year+"_MC_Syst_wNormUncSept14.root", "hist", kBlack, 1.0, true, 0},
         };
 
         rsyst = {
-            {"RSYST",  path + "/"+year+"_MC_Ratio_Syst_wNormUncJan08.root", "hist", kBlack, 1.0, true, 0},
+            {"RSYST",  path + "/"+year+"_MC_Ratio_Syst_wNormUncSept14.root", "hist", kBlack, 1.0, true, 0},
         };
     }
 }
@@ -71,31 +74,34 @@ int main(int argc, char *argv[])
     std::string year = "2018post";
     std::string directory = "";
     int approved = 0;
+    int supplementary = 0;
 
     static struct option long_options[] = {
         {"year",      required_argument, 0, 'y'},
         {"directory", required_argument, 0, 't'},
         {"approved",  optional_argument, 0, 'a'},
+        {"approved",  optional_argument, 0, 's'},
     };
 
-    while((opt = getopt_long(argc, argv, "y:t:a:", long_options, &option_index)) != -1)
+    while((opt = getopt_long(argc, argv, "y:t:a:s:", long_options, &option_index)) != -1)
     {
         switch(opt)
         {
             case 't': directory = optarg; break;
             case 'y': year = optarg; break;
             case 'a': approved = std::stoi(optarg); break;
+            case 's': supplementary = std::stoi(optarg); break;
         }
     }
 
     std::string path = "condor/hadded/" + directory + "/" + year;
 
     std::vector<histInfo> data, bg, sig, syst, rsyst;
-    setHistInfo(path, data, bg, sig, syst, rsyst, year);
+    setHistInfo(path, data, bg, sig, syst, rsyst, year, supplementary);
     HistInfoCollection histInfoCollection(data, bg, sig, syst, rsyst);
 
     //make plotter object with the required sources for histograms specified
-    Plotter plt(std::move(histInfoCollection), "PlotsForLegacyAna/" + directory + "/" +year);
+    Plotter plt(std::move(histInfoCollection), "PlotsForLegacyAna/" + year);
 
     double lumi = 0.0;
     if      (year == "2016")     lumi = 35900.0;
@@ -114,22 +120,18 @@ int main(int argc, char *argv[])
 
     for(std::string mycut : mycuts_1l)
     {
-        plt.plotStack("h_deepESM"+mycut, "S_{NN}" ,            "Events",        false, 10, true, true, 999.9, -999.9, lumi, approved);
-        plt.plotStack("h_njets"+mycut,   "N_{jets}" ,          "Events / bin",  true,  -1, true, true, 999.9, -999.9, lumi, approved);
-        plt.plotStack("h_mbl"+mycut,     "M(l,b) [GeV]",       "Events / bin",  true,  10, true, true, 999.9, -999.9, lumi, approved);
-        plt.plotStack("h_ht"+mycut,      "H_{T} [GeV]",        "Events / bin",  true,  10, true, true, 999.9, -999.9, lumi, approved);
-        plt.plotStack("h_lPt"+mycut,     "Lepton p_{T} [GeV]", "Leptons / bin", true,  2,  true, true, 0,     1000,   lumi, approved);
-        plt.plotStack("h_lEta"+mycut,    "Lepton #eta",        "Leptons / bin", false, 10, true, true, 999.9, -999.9, lumi, approved);
-        plt.plotStack("h_lPhi"+mycut,    "Lepton #phi",        "Leptons / bin", false, 2,  true, true, 999.9, -999.9, lumi, approved);
-        plt.plotStack("h_jPt"+mycut,     "Jet p_{T} [GeV]",    "Jets / bin",    true,  2,  true, true, 0,     1000,   lumi, approved);
+        plt.plotStack("h_deepESM"+mycut, "S_{NN}" ,            "Events",        false, 10, true, true, 999.9, -999.9, lumi, false, approved);
+        plt.plotStack("h_njets"+mycut,   "N_{jets}" ,          "Events / bin",  true,  -1, true, true, 999.9, -999.9, lumi, false, approved);
+        plt.plotStack("h_mbl"+mycut,     "M(l,b) [GeV]",       "Events / bin",  true,  10, true, true, 999.9, -999.9, lumi, false, approved);
+        plt.plotStack("h_ht"+mycut,      "H_{T} [GeV]",        "Events / bin",  true,  10, true, true, 999.9, -999.9, lumi, false, approved);
     }
 
-    plt.plotStack( "fwm2_top6_1l_ge7j_ge1b",    "FWM2", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, approved);
-    plt.plotStack( "fwm3_top6_1l_ge7j_ge1b",    "FWM3", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, approved);
-    plt.plotStack( "fwm4_top6_1l_ge7j_ge1b",    "FWM4", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, approved);
-    plt.plotStack( "jmt_ev0_top6_1l_ge7j_ge1b", "JMT0", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, approved);
-    plt.plotStack( "jmt_ev1_top6_1l_ge7j_ge1b", "JMT1", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, approved);
-    plt.plotStack( "jmt_ev2_top6_1l_ge7j_ge1b", "JMT2", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, approved);
+    plt.plotStack( "fwm2_top6_1l_ge7j_ge1b",    "FWM2", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, supplementary, approved);
+    plt.plotStack( "fwm3_top6_1l_ge7j_ge1b",    "FWM3", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, supplementary, approved);
+    plt.plotStack( "fwm4_top6_1l_ge7j_ge1b",    "FWM4", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, supplementary, approved);
+    plt.plotStack( "jmt_ev0_top6_1l_ge7j_ge1b", "JMT0", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, supplementary, approved);
+    plt.plotStack( "jmt_ev1_top6_1l_ge7j_ge1b", "JMT1", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, supplementary, approved);
+    plt.plotStack( "jmt_ev2_top6_1l_ge7j_ge1b", "JMT2", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, supplementary, approved);
     for(unsigned int i = 0; i < 7; i++)
     {
         std::string order = "";
@@ -144,9 +146,9 @@ int main(int argc, char *argv[])
             case 6: order = "Seventh"; break;
         }
  
-        plt.plotStack("Jet_cm_pt_"+std::to_string(i+1)+"_1l_ge7j_ge1b",  order + " Jet" + " p_{T} [GeV]", "Events / 30 GeV", true,   3, true, true, 0, 1500, lumi, approved);
-        plt.plotStack("Jet_cm_eta_"+std::to_string(i+1)+"_1l_ge7j_ge1b", order + " Jet" + " #eta",        "Events / bin",    false,  1, true, true, -6, 6, lumi, approved);
-        plt.plotStack("Jet_cm_phi_"+std::to_string(i+1)+"_1l_ge7j_ge1b", order + " Jet" + " #phi",        "Events / bin",    false,  1, true, true, -4, 4, lumi, approved);
-        plt.plotStack("Jet_cm_m_"+std::to_string(i+1)  +"_1l_ge7j_ge1b", order + " Jet" + " Mass [GeV]",  "Events / 5 GeV",  false,  5, true, true,  0, 200, lumi, approved);
+        plt.plotStack("Jet_cm_pt_"+std::to_string(i+1)+"_1l_ge7j_ge1b",  order + " Jet" + " p_{T} [GeV]", "Events / 30 GeV", true,   3, true, true, 0,  1500, lumi, supplementary, approved);
+        plt.plotStack("Jet_cm_eta_"+std::to_string(i+1)+"_1l_ge7j_ge1b", order + " Jet" + " #eta",        "Events / bin",    false,  1, true, true, -6, 6,    lumi, supplementary, approved);
+        plt.plotStack("Jet_cm_phi_"+std::to_string(i+1)+"_1l_ge7j_ge1b", order + " Jet" + " #phi",        "Events / bin",    false,  1, true, true, -4, 4,    lumi, supplementary, approved);
+        plt.plotStack("Jet_cm_m_"+std::to_string(i+1)  +"_1l_ge7j_ge1b", order + " Jet" + " Mass [GeV]",  "Events / 5 GeV",  false,  5, true, true, 0,  200,  lumi, supplementary, approved);
     }
 }

--- a/Analyzer/test/plot_1l_LegacyAna.C
+++ b/Analyzer/test/plot_1l_LegacyAna.C
@@ -13,7 +13,7 @@ public:
     std::string plotName_;
 };
 
-void setHistInfo(const std::string& path, std::vector<histInfo>& data, std::vector<histInfo>& bg, std::vector<histInfo>& sig, std::vector<histInfo>& syst, std::vector<histInfo>& rsyst, const std::string& year, int color = 0, const bool doQCD = false)
+void setHistInfo(const std::string& path, std::vector<histInfo>& data, std::vector<histInfo>& bg, std::vector<histInfo>& sig, std::vector<histInfo>& syst, std::vector<histInfo>& rsyst, const std::string& year, const bool doQCD = false)
 {
     //entry for data
     //this uses the initializer syntax to initialize the histInfo object
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
     std::string path = "condor/hadded/" + directory + "/" + year;
 
     std::vector<histInfo> data, bg, sig, syst, rsyst;
-    setHistInfo(path, data, bg, sig, syst, rsyst, year, 1);
+    setHistInfo(path, data, bg, sig, syst, rsyst, year);
     HistInfoCollection histInfoCollection(data, bg, sig, syst, rsyst);
 
     //make plotter object with the required sources for histograms specified

--- a/Analyzer/test/plot_1l_LegacyAna.C
+++ b/Analyzer/test/plot_1l_LegacyAna.C
@@ -1,0 +1,152 @@
+#include "Analyzer/Analyzer/test/plotterLegacyAna.h"
+#include <iostream>
+#include <getopt.h>
+
+// This plotting script is setup to make Fig. 2 of the SUS-19-004 paper
+// as well as the supplementary plots in Fig. 9 and 10 found on the twiki page
+// https://twiki.cern.ch/twiki/bin/view/CMS/SUS19004SupplementaryMaterial
+
+class FisherHolder
+{
+public:
+    std::vector<std::string> cutNames_;
+    std::string plotName_;
+};
+
+void setHistInfo(const std::string& path, std::vector<histInfo>& data, std::vector<histInfo>& bg, std::vector<histInfo>& sig, std::vector<histInfo>& syst, std::vector<histInfo>& rsyst, const std::string& year, int color = 0, const bool doQCD = false)
+{
+    //entry for data
+    //this uses the initializer syntax to initialize the histInfo object
+    //               leg entry root file                 draw options  draw color
+    data = {
+        {"Data" , path + "/"+year+"_Data.root", "PEX0", kBlack},
+    };
+    
+    if (!doQCD) {
+        bg = {
+            {"t#bar{t} + X", path + "/"+year+"_TTX.root",   "hist", kOrange + 2  , 1.0, true, 0},
+            {"QCD multijet", path + "/"+year+"_QCD.root",   "hist", kGreen + 1   , 1.0, true, 0},
+            {"Other",        path + "/"+year+"_Other.root", "hist", kMagenta + 2 , 1.0, true, 0},        
+            {"t#bar{t}",     path + "/"+year+"_TT.root",    "hist", kBlue - 6    , 1.0, true, 0},
+        };
+    } else {
+        bg = {
+            {"t#bar{t} + X", path + "/"+year+"_TTX.root",   "hist", kOrange + 2  , 1.0, true, 0},
+            {"Other",        path + "/"+year+"_Other.root", "hist", kMagenta + 2 , 1.0, true, 0},        
+            {"t#bar{t}",     path + "/"+year+"_TT.root",    "hist", kBlue - 6    , 1.0, true, 0},
+            {"QCD multijet", path + "/"+year+"_QCD.root",   "hist", kGreen + 1   , 1.0, true, 0},
+        };
+    }
+
+    //sig = {        
+    //    {"RPV m_{#tilde{t}} = 350 GeV (#sigma_{#tilde{t} #bar{#tilde{t}}} #times 4)", path + "/"+year+"_RPV_2t6j_mStop-350.root",  "hist", kMagenta, printNEvents, 4.0, false, 2},
+    //    {"RPV m_{#tilde{t}} = 850 GeV (#sigma_{#tilde{t} #bar{#tilde{t}}} #times 16)", path + "/"+year+"_RPV_2t6j_mStop-850.root",  "hist", kRed   , printNEvents, 16.0, false, 3},
+    //    {"Stealth SYY m_{#tilde{t}} = 350 GeV (#sigma_{#tilde{t} #bar{#tilde{t}}} #times 4)", path + "/"+year+"_StealthSYY_2t6j_mStop-350.root",  "hist", kCyan + 1, printNEvents, 4.0, false, 1},        
+    //    {"Stealth SYY m_{#tilde{t}} = 850 GeV (#sigma_{#tilde{t} #bar{#tilde{t}}} #times 16)", path + "/"+year+"_StealthSYY_2t6j_mStop-850.root",  "hist", kBlue, printNEvents, 16.0, false, 4},        
+    //};
+
+    sig = {        
+        {"RPV m_{#tilde{t}} = 350 GeV)",         path + "/"+year+"_RPV_2t6j_mStop-350.root",        "hist", kMagenta,  1.0, false, 2},
+        {"RPV m_{#tilde{t}} = 850 GeV)",         path + "/"+year+"_RPV_2t6j_mStop-850.root",        "hist", kRed,      1.0, false, 3},
+        {"Stealth SYY m_{#tilde{t}} = 350 GeV)", path + "/"+year+"_StealthSYY_2t6j_mStop-350.root", "hist", kCyan + 1, 1.0, false, 1},        
+        {"Stealth SYY m_{#tilde{t}} = 850 GeV)", path + "/"+year+"_StealthSYY_2t6j_mStop-850.root", "hist", kBlue,     1.0, false, 4},        
+    };
+
+    if (!doQCD) {
+        syst = {
+            {"SYST",   path + "/"+year+"_MC_Syst_wNormUncJan08.root", "hist", kBlack, 1.0, true, 0},
+        };
+
+        rsyst = {
+            {"RSYST",  path + "/"+year+"_MC_Ratio_Syst_wNormUncJan08.root", "hist", kBlack, 1.0, true, 0},
+        };
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    TH1::AddDirectory(false);
+
+    int opt, option_index = 0;    
+    std::string year = "2018post";
+    std::string directory = "";
+    int approved = 0;
+
+    static struct option long_options[] = {
+        {"year",      required_argument, 0, 'y'},
+        {"directory", required_argument, 0, 't'},
+        {"approved",  optional_argument, 0, 'a'},
+    };
+
+    while((opt = getopt_long(argc, argv, "y:t:a:", long_options, &option_index)) != -1)
+    {
+        switch(opt)
+        {
+            case 't': directory = optarg; break;
+            case 'y': year = optarg; break;
+            case 'a': approved = std::stoi(optarg); break;
+        }
+    }
+
+    std::string path = "condor/hadded/" + directory + "/" + year;
+
+    std::vector<histInfo> data, bg, sig, syst, rsyst;
+    setHistInfo(path, data, bg, sig, syst, rsyst, year, 1);
+    HistInfoCollection histInfoCollection(data, bg, sig, syst, rsyst);
+
+    //make plotter object with the required sources for histograms specified
+    Plotter plt(std::move(histInfoCollection), "PlotsForLegacyAna/" + directory + "/" +year);
+
+    double lumi = 0.0;
+    if      (year == "2016")     lumi = 35900.0;
+    else if (year == "2017")     lumi = 41500.0;
+    else if (year == "2018pre")  lumi = 21100.0;
+    else if (year == "2018post") lumi = 38700.0;
+    else if (year == "2020")     lumi = 101300.0;
+
+    // --------------------
+    // - Make stack plots
+    // --------------------
+
+    std::vector<std::string> mycuts_1l = {
+        "_1l_HT300_ge7j_ge1b_Mbl",
+    };
+
+    for(std::string mycut : mycuts_1l)
+    {
+        plt.plotStack("h_deepESM"+mycut, "S_{NN}" ,            "Events",        false, 10, true, true, 999.9, -999.9, lumi, approved);
+        plt.plotStack("h_njets"+mycut,   "N_{jets}" ,          "Events / bin",  true,  -1, true, true, 999.9, -999.9, lumi, approved);
+        plt.plotStack("h_mbl"+mycut,     "M(l,b) [GeV]",       "Events / bin",  true,  10, true, true, 999.9, -999.9, lumi, approved);
+        plt.plotStack("h_ht"+mycut,      "H_{T} [GeV]",        "Events / bin",  true,  10, true, true, 999.9, -999.9, lumi, approved);
+        plt.plotStack("h_lPt"+mycut,     "Lepton p_{T} [GeV]", "Leptons / bin", true,  2,  true, true, 0,     1000,   lumi, approved);
+        plt.plotStack("h_lEta"+mycut,    "Lepton #eta",        "Leptons / bin", false, 10, true, true, 999.9, -999.9, lumi, approved);
+        plt.plotStack("h_lPhi"+mycut,    "Lepton #phi",        "Leptons / bin", false, 2,  true, true, 999.9, -999.9, lumi, approved);
+        plt.plotStack("h_jPt"+mycut,     "Jet p_{T} [GeV]",    "Jets / bin",    true,  2,  true, true, 0,     1000,   lumi, approved);
+    }
+
+    plt.plotStack( "fwm2_top6_1l_ge7j_ge1b",    "FWM2", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, approved);
+    plt.plotStack( "fwm3_top6_1l_ge7j_ge1b",    "FWM3", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, approved);
+    plt.plotStack( "fwm4_top6_1l_ge7j_ge1b",    "FWM4", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, approved);
+    plt.plotStack( "jmt_ev0_top6_1l_ge7j_ge1b", "JMT0", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, approved);
+    plt.plotStack( "jmt_ev1_top6_1l_ge7j_ge1b", "JMT1", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, approved);
+    plt.plotStack( "jmt_ev2_top6_1l_ge7j_ge1b", "JMT2", "Events / bin", false, 1, true, true, 999.0, -999.9, lumi, approved);
+    for(unsigned int i = 0; i < 7; i++)
+    {
+        std::string order = "";
+        switch (i)
+        {
+            case 0: order = "Leading"; break;
+            case 1: order = "Subleading"; break;
+            case 2: order = "Third"; break;
+            case 3: order = "Fourth"; break;
+            case 4: order = "Fifth"; break;
+            case 5: order = "Sixth"; break;
+            case 6: order = "Seventh"; break;
+        }
+ 
+        plt.plotStack("Jet_cm_pt_"+std::to_string(i+1)+"_1l_ge7j_ge1b",  order + " Jet" + " p_{T} [GeV]", "Events / 30 GeV", true,   3, true, true, 0, 1500, lumi, approved);
+        plt.plotStack("Jet_cm_eta_"+std::to_string(i+1)+"_1l_ge7j_ge1b", order + " Jet" + " #eta",        "Events / bin",    false,  1, true, true, -6, 6, lumi, approved);
+        plt.plotStack("Jet_cm_phi_"+std::to_string(i+1)+"_1l_ge7j_ge1b", order + " Jet" + " #phi",        "Events / bin",    false,  1, true, true, -4, 4, lumi, approved);
+        plt.plotStack("Jet_cm_m_"+std::to_string(i+1)  +"_1l_ge7j_ge1b", order + " Jet" + " Mass [GeV]",  "Events / 5 GeV",  false,  5, true, true,  0, 200, lumi, approved);
+    }
+}

--- a/Analyzer/test/plotterLegacyAna.h
+++ b/Analyzer/test/plotterLegacyAna.h
@@ -1,0 +1,341 @@
+#ifndef PLOTTERLEGACYANA_H
+#define PLOTTERLEGACYANA_H
+
+#include "TH1.h"
+#include "THStack.h"
+#include "TFile.h"
+#include "TCanvas.h"
+#include "TLegend.h"
+#include "TLatex.h"
+#include "TGraph.h"
+#include "TStyle.h"
+#include "TF1.h"
+#include "TString.h"
+#include "TPaveText.h"
+#include "HistInfoCollectionLegacyAna.h"
+#include "Framework/Framework/include/Utility.h"
+
+#include <memory>
+#include <vector>
+#include <string>
+#include <cstdio>
+#include <iostream>
+#include <map>
+
+class Plotter
+{
+private:
+    //Collection of histInfo
+    HistInfoCollection hc_;
+    std::shared_ptr<TH1> hbgSum_;
+    std::map< std::string, HistInfoCollection > mhc_;
+    std::vector<std::shared_ptr<TH1>> hbgSumVec_;
+    std::string outpath_;
+
+public:
+    Plotter(HistInfoCollection&& hc, const std::string& outpath = "outputPlots") : hc_(hc), outpath_(outpath){}
+    Plotter(std::map< std::string, HistInfoCollection >&& mhc, const std::string& outpath = "outputPlots") : mhc_(mhc), outpath_(outpath){}
+
+    void plotStack(const std::string& histName, const std::string& xAxisLabel, const std::string& yAxisLabel = "Events", const bool isLogY = false, int rebin = -1, const bool scale = false, const bool doFill = true, const double xmin = 999.9, const double xmax = -999.9, double lumi = 36100, bool approved = true, double padDiv = 0.3)
+    {
+        //This is a magic incantation to disassociate opened histograms from their files so the files can be closed
+        TH1::AddDirectory(false);
+
+        double xTitleSize = 0.065; double yTitleSize = 0.065;
+        double xLabelSize = 0.045;  double yLabelSize = 0.045;
+        double xOffset = 2.0;      double yOffset = 1.1;
+        double sf = (1.0-padDiv)/padDiv;
+        //create the canvas for the plot
+        TCanvas *c = new TCanvas("c1", "c1", 800, 800);
+        //switch to the canvas to ensure it is the active object
+        c->cd();
+
+        // Upper plot will be in pad1: TPad(x1, y1, x2, y2)
+        TPad *pad1 = new TPad("pad1", "pad1", 0.0, padDiv, 1.0, 1.0);
+        pad1->SetBottomMargin(0.); // Upper and lower plot are joined
+        pad1->SetLeftMargin(0.14); // Upper and lower plot are joined
+        pad1->SetRightMargin(0.05);
+        pad1->Draw();             // Draw the upper pad: pad1
+        pad1->cd();               // pad1 becomes the current pad
+        
+        //Create TLegend
+        TLegend *leg = new TLegend(0.17, 0.50, 0.35, 0.88);
+        leg->SetFillStyle(0);
+        leg->SetColumnSeparation(0.15);
+        leg->SetBorderSize(0);
+        leg->SetLineWidth(1);
+        leg->SetNColumns(1);
+        leg->SetTextFont(42);
+        leg->SetTextSize(0.040);
+
+        TLegend *dataleg = new TLegend(0.26, 0.50, 0.40, 0.88);
+        dataleg->SetFillStyle(0);
+        dataleg->SetColumnSeparation(0.15);
+        dataleg->SetBorderSize(0);
+        dataleg->SetLineWidth(1);
+        dataleg->SetNColumns(1);
+        dataleg->SetTextFont(42);
+        dataleg->SetTextSize(0.040);
+
+        TLegend *sigleg = new TLegend(0.40, 0.60, 0.84, 0.89);
+        sigleg->SetFillStyle(0);
+        sigleg->SetColumnSeparation(0.15);
+        sigleg->SetBorderSize(0);
+        sigleg->SetLineWidth(1);
+        sigleg->SetNColumns(1);
+        sigleg->SetTextFont(42);
+        sigleg->SetTextSize(0.040);
+
+        // ------------------------
+        // -  Setup plots
+        // ------------------------
+        THStack *bgStack = new THStack();
+        hc_.setUpBG(histName, rebin, bgStack, hbgSum_, doFill, scale);
+
+        hc_.setUpSignal(histName, rebin);
+
+        hc_.setUpData(histName, rebin);
+
+        hc_.setUpSyst(histName);
+
+        //create a dummy histogram to act as the axes
+        histInfo dummy(new TH1D("dummy", "dummy", 1000, hbgSum_->GetBinLowEdge(1), hbgSum_->GetBinLowEdge(hbgSum_->GetNbinsX()) + hbgSum_->GetBinWidth(hbgSum_->GetNbinsX())));        
+
+        //draw dummy axes
+        dummy.setupAxes(xOffset, yOffset, xTitleSize, yTitleSize, xLabelSize, yLabelSize);
+        dummy.draw();
+
+        //Switch to logY if desired
+        gPad->SetLogy(isLogY);
+        gPad->SetTicks(1,1);
+
+        //get maximum from histos and fill TLegend
+        double min = 0.0;
+        double max = 0.0;
+        double lmax = 0.0;
+
+        // -----------------------
+        // -  Plot Background
+        // -----------------------
+        TString legType = (doFill) ? "F" : "L";
+        if (hc_.bgVec_.size() != 0) {
+            for(auto& entry : hc_.bgVec_)
+            {
+                leg->AddEntry(entry.h.get(), entry.legEntry.c_str(), legType);
+            }
+            smartMax(hbgSum_.get(), leg, static_cast<TPad*>(gPad), min, max, lmax, false);
+            bgStack->Draw("same");
+        }
+
+        // -------------------------
+        // -   Plot Signal
+        // -------------------------
+        if (hc_.sigVec_.size() != 0) {
+            for(const auto& entry : hc_.sigVec_)
+            {
+                sigleg->AddEntry(entry.h.get(), entry.legEntry.c_str(), "L");
+                smartMax(entry.h.get(), leg, static_cast<TPad*>(gPad), min, max, lmax, false);
+                entry.draw();
+            }
+        }
+
+        //------------------------
+        //-  Plot Data
+        //------------------------
+        if (hc_.dataVec_.size() != 0) {
+            dataleg->AddEntry((TObject*)0, "", "");
+            dataleg->AddEntry((TObject*)0, "", "");
+            dataleg->AddEntry((TObject*)0, "", "");
+
+            for(const auto& entry : hc_.dataVec_)
+            {
+                legType = (entry.drawOptions=="hist") ? "L" : entry.drawOptions;
+                dataleg->AddEntry(entry.h.get(), entry.legEntry.c_str(), legType);
+                smartMax(entry.h.get(), leg, static_cast<TPad*>(gPad), min, max, lmax, true);
+                entry.draw();
+                entry.h->Draw("E0 SAME");
+            }
+
+        }
+
+        if (hc_.systVec_.size() != 0) {
+            for(const auto& entry : hc_.systVec_)
+            {
+                smartMax(entry.h.get(), leg, static_cast<TPad*>(gPad), min, max, lmax, true);
+                entry.ge->Draw("2SAME");
+            }
+        }
+
+
+        //plot legend
+        leg->Draw("same");
+        dataleg->Draw("same");
+        sigleg->Draw("same");
+
+        TLatex significance;  
+        significance.SetNDC(true);
+        significance.SetTextAlign(11);
+        significance.SetTextFont(52);
+        significance.SetTextSize(0.030);
+
+        //Draw CMS and lumi lables
+        drawLables(lumi, approved);
+            
+        //Draw dummy hist again to get axes on top of histograms
+        setupDummy(dummy, sigleg, "", yAxisLabel, isLogY, xmin, xmax, min, max, lmax);
+        dummy.setupAxes(xOffset, yOffset, xTitleSize, yTitleSize, xLabelSize, yLabelSize);
+
+        dummy.draw("AXIS");
+                        
+        // lower plot will be in pad2
+        c->cd();          // Go back to the main canvas before defining pad2
+        TPad *pad2 = new TPad("pad2", "pad2", 0.0, 0.0, 1.0, padDiv);
+        pad2->SetTopMargin(0.);
+        pad2->SetBottomMargin(0.30);
+        pad2->SetRightMargin(0.05);
+        pad2->SetLeftMargin(0.14);
+        pad2->SetGridy(); // Horizontal grid
+        pad2->Draw();
+        pad2->cd();       // pad2 becomes the current pad        
+        gPad->SetTicks(1,1);
+            
+        //make ratio dummy
+        histInfo ratioDummy(new TH1D("rdummy", "rdummy", 1000, hc_.bgVec_[0].h->GetBinLowEdge(1), 
+                                     hc_.bgVec_[0].h->GetBinLowEdge(hc_.bgVec_[0].h->GetNbinsX()) + hc_.bgVec_[0].h->GetBinWidth(hc_.bgVec_[0].h->GetNbinsX())));
+        ratioDummy.h->GetXaxis()->SetTitle(xAxisLabel.c_str());
+        ratioDummy.h->GetYaxis()->SetTitle("Data / MC");
+
+        ratioDummy.h->GetXaxis()->SetTickLength(0.1);
+        ratioDummy.h->GetYaxis()->SetTickLength(0.045);
+        ratioDummy.setupAxes(xOffset/sf, yOffset/sf, xTitleSize*sf, yTitleSize*sf, xLabelSize*sf, yLabelSize*sf);
+        ratioDummy.h->GetYaxis()->SetNdivisions(3,5,0);
+        ratioDummy.h->GetXaxis()->SetRangeUser(xmin, xmax);
+        ratioDummy.h->GetYaxis()->SetRangeUser(0.0, 5.0);
+        ratioDummy.h->SetStats(0);
+        ratioDummy.h->SetMinimum(0.4);
+        ratioDummy.h->SetMaximum(1.6);
+            
+        //Make ratio histogram for data / background.
+        histInfo ratio((TH1*)hc_.dataVec_[0].h->Clone());
+                
+        ratio.drawOptions = "ep";
+        ratio.color = kBlack;
+            
+        ratio.h->Divide(hbgSum_.get());
+        ratio.h->SetMarkerStyle(20);
+            
+        ratioDummy.draw();
+        ratio.draw("same");
+            
+        if (hc_.rsystVec_.size() != 0) {
+            for(const auto& entry : hc_.rsystVec_)
+            {
+                entry.ge->Draw("2SAME");
+            }
+        }
+
+        ratio.draw("same");
+        ratio.h->Draw("E0 SAME");
+
+        pad1->cd();
+
+        //save new plot to file
+        if (not approved) {
+            c->Print((outpath_ + "/" + histName + "_prelim.pdf").c_str());
+        } else {
+            c->Print((outpath_ + "/" + histName + ".pdf").c_str());
+        }
+
+        //clean up dynamic memory
+        delete c;
+        delete leg;
+        delete sigleg;
+        delete bgStack;
+    }
+
+    //This is a helper function which will keep the plot from overlapping with the legend
+    void smartMax(const TH1* const h, const TLegend* const l, const TPad* const p, double& gmin, double& gmax, double& gpThreshMax, const bool error)
+    {
+        const bool isLog = p->GetLogy();
+        double min = 9e99;
+        double max = -9e99;
+        double pThreshMax = -9e99;
+        int threshold = static_cast<int>(h->GetNbinsX()*(l->GetX1() - p->GetLeftMargin())/((1 - p->GetRightMargin()) - p->GetLeftMargin()));
+
+        for(int i = 1; i <= h->GetNbinsX(); ++i)
+        {
+            double bin = 0.0;
+            if(error) bin = h->GetBinContent(i) + h->GetBinError(i);
+            else      bin = h->GetBinContent(i);
+            if(bin > max) max = bin;
+            else if(bin > 1e-10 && bin < min) min = bin;
+            if(i >= threshold && bin > pThreshMax) pThreshMax = bin;
+        }
+        
+        gpThreshMax = std::max(gpThreshMax, pThreshMax);
+        if (isLog) gmax = 10*std::max(gmax, max);
+        else gmax = 1.05*std::max(gmax, max);
+        gmin = std::min(gmin, min);
+    }
+
+    void setupDummy(histInfo dummy, TLegend *leg, const std::string& xAxisLabel, const std::string& yAxisLabel, const bool isLogY, 
+                    const double xmin, const double xmax, double min, double max, double lmax)
+    {
+        dummy.setupAxes(1.2, 1.4, 0.065, 0.065, 0.045, 0.045);
+        dummy.h->GetYaxis()->SetTitle(yAxisLabel.c_str());
+        dummy.h->GetXaxis()->SetTitle(xAxisLabel.c_str());
+        dummy.h->SetTitle("");
+        //Set the y-range of the histogram
+        if(isLogY)
+        {
+            double locMin = std::min(0.2, std::max(0.2, 0.05 * min));
+            double legSpan = (log10(3*max) - log10(locMin)) * (leg->GetY1() - gPad->GetBottomMargin()) / ((1 - gPad->GetTopMargin()) - gPad->GetBottomMargin());
+            double legMin = legSpan + log10(locMin);
+            if(log10(lmax) > legMin)
+            {
+                double scale = (log10(lmax) - log10(locMin)) / (legMin - log10(locMin));
+                max = pow(max/locMin, scale)*locMin;
+            }
+            dummy.h->GetYaxis()->SetRangeUser(locMin, 10*max);
+        }
+        else
+        {
+            double locMin = 0.0;
+            double legMin = (1.2*max - locMin) * (leg->GetY1() - gPad->GetBottomMargin()) / ((1 - gPad->GetTopMargin()) - gPad->GetBottomMargin());
+            if(lmax > legMin) max *= (lmax - locMin)/(legMin - locMin);
+            dummy.h->GetYaxis()->SetRangeUser(1.0, max*1.4);
+        }
+        //set x-axis range
+        if(xmin < xmax) dummy.h->GetXaxis()->SetRangeUser(xmin, xmax);
+    }
+
+    void drawLables(double lumi, bool approved = false)
+    {
+        //Draw CMS and lumi lables
+        char lumistamp[128];
+        if (lumi > 100000) sprintf(lumistamp, "%.0f fb^{-1} (13 TeV)", lumi / 1000.0);
+        else sprintf(lumistamp, "%.1f fb^{-1} (13 TeV)", lumi / 1000.0);
+
+        TLatex mark;
+        mark.SetNDC(true);
+
+        //Draw CMS mark
+        mark.SetTextAlign(11);
+        mark.SetTextSize(0.065);
+        mark.SetTextFont(61);
+        mark.DrawLatex(gPad->GetLeftMargin(), 1 - (gPad->GetTopMargin() - 0.017), "CMS"); // #scale[0.8]{#it{Preliminary}}");
+        //mark.SetTextSize(0.040);
+        mark.SetTextFont(52);
+        //mark.DrawLatex(gPad->GetLeftMargin() + 0.1, 1 - (gPad->GetTopMargin() - 0.017), "Stealth 2018");
+        //if (not approved) mark.DrawLatex(gPad->GetLeftMargin() + 0.1025, 1 - (gPad->GetTopMargin() - 0.017), "Preliminary");
+        if (not approved) mark.DrawLatex(gPad->GetLeftMargin() + 0.1025, 1 - (gPad->GetTopMargin() - 0.017), "Supplementary");
+        else mark.DrawLatex(gPad->GetLeftMargin() + 0.1025, 1 - (gPad->GetTopMargin() - 0.017), "");
+
+        //Draw lumistamp
+        mark.SetTextFont(42);
+        mark.SetTextAlign(31);
+        mark.DrawLatex(1 - gPad->GetRightMargin(), 1 - (gPad->GetTopMargin() - 0.017), lumistamp);        
+    }    
+};
+
+#endif

--- a/Analyzer/test/plotterLegacyAna.h
+++ b/Analyzer/test/plotterLegacyAna.h
@@ -36,7 +36,7 @@ public:
     Plotter(HistInfoCollection&& hc, const std::string& outpath = "outputPlots") : hc_(hc), outpath_(outpath){}
     Plotter(std::map< std::string, HistInfoCollection >&& mhc, const std::string& outpath = "outputPlots") : mhc_(mhc), outpath_(outpath){}
 
-    void plotStack(const std::string& histName, const std::string& xAxisLabel, const std::string& yAxisLabel = "Events", const bool isLogY = false, int rebin = -1, const bool scale = false, const bool doFill = true, const double xmin = 999.9, const double xmax = -999.9, double lumi = 36100, bool approved = true, double padDiv = 0.3)
+    void plotStack(const std::string& histName, const std::string& xAxisLabel, const std::string& yAxisLabel = "Events", const bool isLogY = false, int rebin = -1, const bool scale = false, const bool doFill = true, const double xmin = 999.9, const double xmax = -999.9, double lumi = 36100, bool supplementary = false, bool approved = true, double padDiv = 0.3)
     {
         //This is a magic incantation to disassociate opened histograms from their files so the files can be closed
         TH1::AddDirectory(false);
@@ -59,7 +59,9 @@ public:
         pad1->cd();               // pad1 becomes the current pad
         
         //Create TLegend
-        TLegend *leg = new TLegend(0.17, 0.50, 0.35, 0.88);
+        TLegend *leg = nullptr;
+        if (not supplementary) leg = new TLegend(0.17, 0.50, 0.35, 0.88);
+        else leg = new TLegend(0.17, 0.46, 0.35, 0.84);
         leg->SetFillStyle(0);
         leg->SetColumnSeparation(0.15);
         leg->SetBorderSize(0);
@@ -68,7 +70,9 @@ public:
         leg->SetTextFont(42);
         leg->SetTextSize(0.040);
 
-        TLegend *dataleg = new TLegend(0.26, 0.50, 0.40, 0.88);
+        TLegend *dataleg = nullptr;
+        if (not supplementary) dataleg = new TLegend(0.26, 0.50, 0.40, 0.88);
+        else dataleg = new TLegend(0.26, 0.46, 0.40, 0.84);
         dataleg->SetFillStyle(0);
         dataleg->SetColumnSeparation(0.15);
         dataleg->SetBorderSize(0);
@@ -77,7 +81,9 @@ public:
         dataleg->SetTextFont(42);
         dataleg->SetTextSize(0.040);
 
-        TLegend *sigleg = new TLegend(0.40, 0.60, 0.84, 0.89);
+        TLegend *sigleg = nullptr;
+        if (not supplementary) sigleg = new TLegend(0.40, 0.56, 0.84, 0.88);
+        else sigleg = new TLegend(0.56, 0.56, 0.82, 0.85);
         sigleg->SetFillStyle(0);
         sigleg->SetColumnSeparation(0.15);
         sigleg->SetBorderSize(0);
@@ -179,7 +185,7 @@ public:
         significance.SetTextSize(0.030);
 
         //Draw CMS and lumi lables
-        drawLables(lumi, approved);
+        drawLables(lumi, supplementary, approved);
             
         //Draw dummy hist again to get axes on top of histograms
         setupDummy(dummy, sigleg, "", yAxisLabel, isLogY, xmin, xmax, min, max, lmax);
@@ -274,7 +280,7 @@ public:
         
         gpThreshMax = std::max(gpThreshMax, pThreshMax);
         if (isLog) gmax = 10*std::max(gmax, max);
-        else gmax = 1.05*std::max(gmax, max);
+        else gmax = 1.06*std::max(gmax, max);
         gmin = std::min(gmin, min);
     }
 
@@ -309,7 +315,7 @@ public:
         if(xmin < xmax) dummy.h->GetXaxis()->SetRangeUser(xmin, xmax);
     }
 
-    void drawLables(double lumi, bool approved = false)
+    void drawLables(double lumi, bool supplementary = false, bool approved = false)
     {
         //Draw CMS and lumi lables
         char lumistamp[128];
@@ -323,18 +329,22 @@ public:
         mark.SetTextAlign(11);
         mark.SetTextSize(0.065);
         mark.SetTextFont(61);
-        mark.DrawLatex(gPad->GetLeftMargin(), 1 - (gPad->GetTopMargin() - 0.017), "CMS"); // #scale[0.8]{#it{Preliminary}}");
-        //mark.SetTextSize(0.040);
+        mark.DrawLatex(gPad->GetLeftMargin(), 1 - (gPad->GetTopMargin() - 0.017), "CMS");
         mark.SetTextFont(52);
-        //mark.DrawLatex(gPad->GetLeftMargin() + 0.1, 1 - (gPad->GetTopMargin() - 0.017), "Stealth 2018");
-        //if (not approved) mark.DrawLatex(gPad->GetLeftMargin() + 0.1025, 1 - (gPad->GetTopMargin() - 0.017), "Preliminary");
-        if (not approved) mark.DrawLatex(gPad->GetLeftMargin() + 0.1025, 1 - (gPad->GetTopMargin() - 0.017), "Supplementary");
+        if (not approved and not supplementary) mark.DrawLatex(gPad->GetLeftMargin() + 0.1025, 1 - (gPad->GetTopMargin() - 0.017), "Preliminary");
+        else if (supplementary) mark.DrawLatex(gPad->GetLeftMargin() + 0.1025, 1 - (gPad->GetTopMargin() - 0.017), "Supplementary");
         else mark.DrawLatex(gPad->GetLeftMargin() + 0.1025, 1 - (gPad->GetTopMargin() - 0.017), "");
 
         //Draw lumistamp
         mark.SetTextFont(42);
         mark.SetTextAlign(31);
         mark.DrawLatex(1 - gPad->GetRightMargin(), 1 - (gPad->GetTopMargin() - 0.017), lumistamp);        
+
+        if (supplementary)
+        {
+            mark.SetTextSize(0.04);
+            mark.DrawLatex(gPad->GetLeftMargin() + 0.24, 1 - (gPad->GetTopMargin() + 0.055), "arXiv XXXX.XXXX");
+        }
     }    
 };
 

--- a/Analyzer/test/ttVsSigNNLegacyAna.py
+++ b/Analyzer/test/ttVsSigNNLegacyAna.py
@@ -144,6 +144,12 @@ for name, options in histDict.iteritems():
     else:
         mark.DrawLatex(ROOT.gPad.GetLeftMargin() + 0.13, 1 - (ROOT.gPad.GetTopMargin() + 0.05), "Simulation Preliminary")
 
+    mark.SetTextAlign(11)
+    mark.SetTextSize(0.025)
+    mark.SetTextFont(42)
+    mark.DrawLatex(ROOT.gPad.GetLeftMargin() + 0.63, 1 - (ROOT.gPad.GetTopMargin() + 0.05), "arXiv:XXXX.XXXX")
+
+    mark.SetTextSize(0.045);
     mark.SetTextFont(42)
     mark.SetTextAlign(31)
     if year == "2016":
@@ -153,6 +159,7 @@ for name, options in histDict.iteritems():
   
     if args.approved:
         c.SaveAs("%s/%s_%s.pdf"%(outpath,year,name.replace("_1l_ge7j_ge1b", "")))
+        c.SaveAs("%s/%s_%s.png"%(outpath,year,name.replace("_1l_ge7j_ge1b", "")))
     else:
         c.SaveAs("%s/%s_%s_prelim.pdf"%(outpath,year,name.replace("_1l_ge7j_ge1b", "")))
-
+        c.SaveAs("%s/%s_%s_prelim.png"%(outpath,year,name.replace("_1l_ge7j_ge1b", "")))

--- a/Analyzer/test/ttVsSigNNLegacyAna.py
+++ b/Analyzer/test/ttVsSigNNLegacyAna.py
@@ -1,0 +1,158 @@
+#! /bin/env/python
+
+# Makes ttbar vs signal plots of NN inputs for 2016 and 2017 for the legacy 1L analysis
+# These plots can be found in Fig. 7 and 8 of the in the analysis supplementary plots twiki
+# https://twiki.cern.ch/twiki/bin/view/CMS/SUS19004SupplementaryMaterial
+
+import ROOT, os, math, array, copy, argparse
+
+ROOT.TH1.AddDirectory(0)
+ROOT.TH1.SetDefaultSumw2()
+ROOT.TH2.SetDefaultSumw2()
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat("")
+ROOT.gStyle.SetPaintTextFormat("3.2f")
+ROOT.gStyle.SetFrameLineWidth(2)
+ROOT.gStyle.SetEndErrorSize(0)
+
+usage = "usage: %prog [options]"
+parser = argparse.ArgumentParser(usage)
+parser.add_argument("--approved", dest="approved", help="Plot is approved",      action="store_true", default=False) 
+parser.add_argument("--year",     dest="year",     help="which year",            required=True)
+parser.add_argument("--inputDir", dest="inputDir", help="Input dir with histos", required=True)
+args = parser.parse_args()
+
+inputDir = args.inputDir
+
+outpath = "./PlotsForSupplementary/"
+if not os.path.exists(outpath): os.makedirs(outpath)
+
+year = args.year
+
+ttf = ROOT.TFile.Open(inputDir + "/%s/%s_TT.root"%(year,year))
+sig1f = ROOT.TFile.Open(inputDir + "/%s/%s_RPV_2t6j_mStop-350.root"%(year,year))
+sig2f = ROOT.TFile.Open(inputDir + "/%s/%s_StealthSYY_2t6j_mStop-750.root"%(year,year))
+
+histDict = {"Jet_cm_pt_1_1l_ge7j_ge1b" : {"X" : {"title" : "Leading Jet p_{T} [GeV]", "rebin" : 2}},
+           "Jet_cm_eta_1_1l_ge7j_ge1b" : {"X" : {"title" : "Leading Jet #eta", "rebin" : 1}},
+           "Jet_cm_phi_1_1l_ge7j_ge1b" : {"X" : {"title" : "Leading Jet #phi", "rebin" : 1}},
+           "Jet_cm_m_1_1l_ge7j_ge1b"   : {"X" : {"title" : "Leading Jet mass [GeV]", "rebin" : 10}},
+           "jmt_ev0_top6_1l_ge7j_ge1b" : {"X" : {"title" : "JMT0", "rebin" : 1}},
+           "jmt_ev1_top6_1l_ge7j_ge1b" : {"X" : {"title" : "JMT1", "rebin" : 1}},
+           "fwm2_top6_1l_ge7j_ge1b"    : {"X" : {"title" : "FWM2", "rebin" : 1}},
+           "fwm4_top6_1l_ge7j_ge1b"    : {"X" : {"title" : "FWM4", "rebin" : 1}}
+}
+
+for name, options in histDict.iteritems():
+
+    c = ROOT.TCanvas("%s_c"%(name), "%s_c"%(name), 2400, 2400)
+    tth = ttf.Get(name)
+    sig1h = sig1f.Get(name)
+    sig2h = sig2f.Get(name)
+
+    tth.GetXaxis().SetTitle(options["X"]["title"])
+
+    tth.Rebin(options["X"]["rebin"])
+    sig1h.Rebin(options["X"]["rebin"])
+    sig2h.Rebin(options["X"]["rebin"])
+
+    sig1col = "#D325D3"
+    sig2col = "#FFA851"
+    ttcol   = "#9999FF"
+    ttcol2  = "#010199"
+
+    tth.Scale(1.0/tth.Integral())
+    sig1h.Scale(1.0/sig1h.Integral())
+    sig2h.Scale(1.0/sig2h.Integral())
+
+    maxBinTT = tth.GetMaximumBin();   theMaxTT = tth.GetBinContent(maxBinTT)
+    maxBinSG = sig2h.GetMaximumBin(); theMaxSG = sig2h.GetBinContent(maxBinSG)
+
+    if theMaxTT > theMaxSG: tth.SetMaximum(theMaxTT*1.5)
+    else:                   tth.SetMaximum(theMaxSG*1.5)
+
+    for xbin in xrange(1, tth.GetNbinsX()+1): tth.SetBinError(xbin, 0.00001)
+    for xbin in xrange(1, sig1h.GetNbinsX()+1): sig1h.SetBinError(xbin, 0.00001)
+    for xbin in xrange(1, sig2h.GetNbinsX()+1): sig2h.SetBinError(xbin, 0.00001)
+
+    tth.SetFillColorAlpha(ROOT.TColor.GetColor(ttcol), 1.0)
+    sig1h.SetFillColor(ROOT.TColor.GetColor(sig1col))
+    sig2h.SetFillColor(ROOT.TColor.GetColor(sig2col))
+
+    tth.SetLineColor(ROOT.TColor.GetColor(ttcol2))
+    sig1h.SetLineColor(ROOT.TColor.GetColor(sig1col))
+    sig2h.SetLineColor(ROOT.TColor.GetColor(sig2col))
+
+    tth.SetMarkerColor(ROOT.TColor.GetColor(ttcol))
+    sig1h.SetMarkerColor(ROOT.TColor.GetColor(sig1col))
+    sig2h.SetMarkerColor(ROOT.TColor.GetColor(sig2col))
+
+    lw = 2
+    tth.SetLineWidth(lw)
+    sig1h.SetLineWidth(lw)
+    sig2h.SetLineWidth(lw)
+
+    ms = 0
+    tth.SetMarkerSize(ms)
+    sig1h.SetMarkerSize(ms)
+    sig2h.SetMarkerSize(ms)
+
+    sig1h.SetFillStyle(3004)
+    sig2h.SetFillStyle(3005)
+
+    ROOT.gPad.SetLogz()
+    
+    ROOT.gPad.SetTopMargin(0.10)
+    ROOT.gPad.SetLeftMargin(0.14)
+    ROOT.gPad.SetBottomMargin(0.12)
+    ROOT.gPad.SetRightMargin(0.04)
+    
+    iamLegend = ROOT.TLegend(ROOT.gPad.GetLeftMargin() + 0.05, 0.70, 1 - ROOT.gPad.GetRightMargin() - 0.05, 0.8)
+    
+    iamLegend.SetTextSize(0.03)
+    iamLegend.SetNColumns(3)
+    iamLegend.SetBorderSize(2)
+    
+    iamLegend.AddEntry(sig1h, "RPV m_{#tilde{t}} = 350 GeV", "F")
+    iamLegend.AddEntry(sig2h, "SYY m_{#tilde{t}} = 750 GeV", "F")
+    iamLegend.AddEntry(tth,   "t#bar{t}", "F")
+
+    tth.SetTitle("")
+    tth.GetYaxis().SetTitle("A.U.")
+    tth.GetYaxis().SetTitleSize(0.05)
+    tth.GetXaxis().SetTitleSize(0.05)
+    tth.GetYaxis().SetLabelSize(0.04)
+    tth.GetXaxis().SetLabelSize(0.04)
+    tth.GetYaxis().SetTitleOffset(1.4)
+    tth.GetXaxis().SetTitleOffset(1.1)
+
+    tth.Draw("HIST")
+    sig1h.Draw("HIST SAME")
+    sig2h.Draw("HIST SAME")
+    iamLegend.Draw("SAME")
+
+    mark = ROOT.TLatex()
+    mark.SetNDC(True)
+
+    mark.SetTextAlign(11);
+    mark.SetTextSize(0.045);
+    mark.SetTextFont(61);
+    mark.DrawLatex(ROOT.gPad.GetLeftMargin() + 0.03, 1 - (ROOT.gPad.GetTopMargin() + 0.05), "CMS")
+    mark.SetTextFont(52);
+    if args.approved:
+        mark.DrawLatex(ROOT.gPad.GetLeftMargin() + 0.13, 1 - (ROOT.gPad.GetTopMargin() + 0.05), "Simulation Supplementary")
+    else:
+        mark.DrawLatex(ROOT.gPad.GetLeftMargin() + 0.13, 1 - (ROOT.gPad.GetTopMargin() + 0.05), "Simulation Preliminary")
+
+    mark.SetTextFont(42)
+    mark.SetTextAlign(31)
+    if year == "2016":
+        mark.DrawLatex(1 - ROOT.gPad.GetRightMargin(), 1 - (ROOT.gPad.GetTopMargin() - 0.015), "2016 (13 TeV)")
+    else:
+        mark.DrawLatex(1 - ROOT.gPad.GetRightMargin(), 1 - (ROOT.gPad.GetTopMargin() - 0.015), "2017 (13 TeV)")
+  
+    if args.approved:
+        c.SaveAs("%s/%s_%s.pdf"%(outpath,year,name.replace("_1l_ge7j_ge1b", "")))
+    else:
+        c.SaveAs("%s/%s_%s_prelim.pdf"%(outpath,year,name.replace("_1l_ge7j_ge1b", "")))
+

--- a/README.md
+++ b/README.md
@@ -161,19 +161,27 @@ Once copied the `DataVsMC` folder locally to the `condor/hadded` path with `Anal
 
 ### Making Figure 2 of the Paper
 
-`./plot_1l_LegacyAna -y 2016 -t DataVsMC -a 1`
-`./plot_1l_LegacyAna -y 2020 -t DataVsMC -a 1` # Here 2020 is synonymous with 2017+2018
+```
+./plot_1l_LegacyAna -y 2016 -t DataVsMC -a 1
+./plot_1l_LegacyAna -y 2020 -t DataVsMC -a 1 # Here 2020 is synonymous with 2017+2018
+```
 
 ### Making Figure 9 and 10 of Supplementary Material
 
-`./plot_1l_LegacyAna -y 2016 -t DataVsMC -a 1 -s 1`
-`./plot_1l_LegacyAna -y 2017 -t DataVsMC -a 1 -s 1`
+```
+./plot_1l_LegacyAna -y 2016 -t DataVsMC -a 1 -s 1
+./plot_1l_LegacyAna -y 2017 -t DataVsMC -a 1 -s 1
+```
 
 ### Making Figure 7 and 8 or Supplementary Material
 
-`python ttVsSigNNLegacyAna.py --year 2016 --approved --inputDir ./condor/hadded/DataVsMC`
-`python ttVsSigNNLegacyAna.py --year 2017 --approved --inputDir ./condor/hadded/DataVsMC`
+```
+python ttVsSigNNLegacyAna.py --year 2016 --approved --inputDir ./condor/hadded/DataVsMC
+python ttVsSigNNLegacyAna.py --year 2017 --approved --inputDir ./condor/hadded/DataVsMC
+```
 
 ### Making Figure 1 of the Supplementary Material
 
-`python makeBinEdgePlotLegacyAna.py --approved`
+```
+python makeBinEdgePlotLegacyAna.py --approved
+```

--- a/README.md
+++ b/README.md
@@ -151,3 +151,29 @@ cd $HOME/../../CMSSW_9_3_3/src/Analyzer/Analyzer/test/
 # For example running on 2018pre
 python njets_systs_comp.py --year 2018pre --fitdir $HOME/../../src/HiggsAnalysis/CombinedLimit/ --fittag Approval_StatErrPlusFullDev_12JetFix --outputdir MYDIR
 ```
+
+## Making Legacy Plots for SUS-19-004
+
+Input ROOT files for making data vs MC stack plots and signal vs background plots, as found in Fig. 2 of the paper and in Fig. 7, 8, 9, and 10 of the supplementary material twiki, are located at:
+`/eos/uscms/store/user/lpcsusyhad/StealthStop/PlotInputs/SUS19004/DataVsMC`
+
+Once copied the `DataVsMC` folder locally to the `condor/hadded` path with `Analyzer/Analyzer/test`, plots can be made using `plot_1l_LegacyAna`.
+
+### Making Figure 2 of the Paper
+
+`./plot_1l_LegacyAna -y 2016 -t DataVsMC -a 1`
+`./plot_1l_LegacyAna -y 2020 -t DataVsMC -a 1` # Here 2020 is synonymous with 2017+2018
+
+### Making Figure 9 and 10 of Supplementary Material
+
+`./plot_1l_LegacyAna -y 2016 -t DataVsMC -a 1 -s 1`
+`./plot_1l_LegacyAna -y 2017 -t DataVsMC -a 1 -s 1`
+
+### Making Figure 7 and 8 or Supplementary Material
+
+`python ttVsSigNNLegacyAna.py --year 2016 --approved --inputDir ./condor/hadded/DataVsMC`
+`python ttVsSigNNLegacyAna.py --year 2017 --approved --inputDir ./condor/hadded/DataVsMC`
+
+### Making Figure 1 of the Supplementary Material
+
+`python makeBinEdgePlotLegacyAna.py --approved`


### PR DESCRIPTION
--cleaned up and made new version of `plot_1l.C`, `plotter.h`, and `HistInfoCollection.h` (appended name "LegacyAna" at end). This code is the latest version that makes stack plots as seen in Fig. 2 of the paper and in the supplementary material.
--add `makeSystBandsLegacyAna.py` which makes the total syst. bands used in Fig. 2 and supplementary material.
--add `njetsStackLegacyAna.py` which makes Fig. 5 in the paper.
--add `ttVsSigNNLegacyAna.py` which makes Fig. 7 and 8 in the supplementary material.
--add `makeBinEdgePlotLegacyAna.py` which makes Fig. 1 of the supplementary material.