### PR TITLE
Need top tagger for 1l by necessity

### DIFF
--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -394,6 +394,7 @@ public:
                 "FatJetCombine",
                 "MakeMVAVariables",
                 "MakeMVAVariables_NonIsoMuon",
+                "RunTopTagger",
                 "Baseline",
                 "DeepEventShape",
                 "DeepEventShape_NonIsoMuon",


### PR DESCRIPTION
--`Baseline.h` requires `ntops` to make zero lepton baseline selections.
--`Analyze1Lep` runs `Baseline.h`, thus need to add `RunTopTagger` to modules list for `Analyzer1Lep`.