### PR TITLE
added new class for Validation Regions as Sub-Division of D Region

### DIFF
--- a/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Classes.py
+++ b/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Classes.py
@@ -1635,6 +1635,8 @@ class ValidationRegions_SubDivisionsOfABCD(FinalBinEdges):
                 if tempClosureErr > 0.0:
                     closureErrsList_subDivD.append(abs(tempClosureErr))
                     closureErrUncList_subDivD.append(tempClosureErrUnc)
+                    disc1KeyOut_subDivD.append(float(disc1Key))
+                    disc2KeyOut_subDivD.append(float(disc2Key)) 
 
                 # get the final edges
                 if abs( ( float(disc1Key) - (float(finalDisc1Edge) / 2.0) ) ) < 0.01 and abs( ( float(disc2Key) - (float(finalDisc2Edge) / 2.0) ) ) < 0.01:
@@ -1649,4 +1651,4 @@ class ValidationRegions_SubDivisionsOfABCD(FinalBinEdges):
                     final_nTot_SigBkg_dC  = nTot_SigBkg_dB
                     final_nTot_SigBkg_dD  = nTot_SigBkg_dD
        
-        return finalDisc1Key_subDivD, finalDisc2Key_subDivD, finalSigFrac_dA, finalSigFrac_dB, finalSigFrac_dC, finalSigFrac_dD, final_nTot_SigBkg_dA, final_nTot_SigBkg_dB, final_nTot_SigBkg_dC, final_nTot_SigBkg_dD, closureErrsList_subDivD, closureErrUncList_subDivD
+        return finalDisc1Key_subDivD, finalDisc2Key_subDivD, finalSigFrac_dA, finalSigFrac_dB, finalSigFrac_dC, finalSigFrac_dD, final_nTot_SigBkg_dA, final_nTot_SigBkg_dB, final_nTot_SigBkg_dC, final_nTot_SigBkg_dD, closureErrsList_subDivD, closureErrUncList_subDivD, disc1KeyOut_subDivD, disc2KeyOut_subDivD

--- a/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Classes.py
+++ b/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Classes.py
@@ -1578,10 +1578,11 @@ class ValidationRegions_SubDivisionsOfABCD(FinalBinEdges):
     # ------------------------------------------------------
     def get_ValidationEdges_SubDivisionsOfABCD(self, nTotSigCount, nTotBkgCount, finalDisc1Edge, finalDisc2Edge):
 
-        disc1KeyOut_subDivD = [];  disc2KeyOut_subDivD = [];  finalDisc1Key_subDivD = -1.0; finalDisc2Key_subDivD = -1.0; 
+        disc1KeyOut_subDivD = [];  disc2KeyOut_subDivD = [];  finalDisc1Key_subDivD = -1.0; finalDisc2Key_subDivD = -1.0;
         finalSigFrac_dA     = 0.0; finalSigFrac_dB     = 0.0; finalSigFrac_dC       = 0.0;  finalSigFrac_dC       = 0.0;  
         nEvents_dAC         = 0.0; nEvents_dBD         = 0.0
-        
+        closureErrsList_subDivD = []; closureErrUncList_subDivD = []       
+ 
         # loop over the disc1 and disc2 to get any possible combination of them
         for disc1Key, disc2s in nTotBkgCount["nBkgEvents_A"].items():
             
@@ -1633,6 +1634,10 @@ class ValidationRegions_SubDivisionsOfABCD(FinalBinEdges):
                 if nBkgEvents_dA > 0.0 and nBkgEvents_dD > 0.0: 
                     tempClosureErr, tempClosureErrUnc = self.cal_ClosureError(nBkgEvents_dA, nBkgEvents_dB, nBkgEvents_dC, nBkgEvents_dD, nBkgEventsErr_dA, nBkgEventsErr_dB, nBkgEventsErr_dC, nBkgEventsErr_dD)
 
+                if tempClosureErr > 0.0:
+                    closureErrsList_subDivD.append(abs(tempClosureErr))
+                    closureErrUncList_subDivD.append(tempClosureErrUnc)
+
                 # get the final edges
                 if abs( ( float(disc1Key) - (float(finalDisc1Edge) / 2.0) ) ) < 0.01 and abs( ( float(disc2Key) - (float(finalDisc2Edge) / 2.0) ) ) < 0.01:
                     finalDisc1Key_subDivD = disc1Key
@@ -1646,4 +1651,4 @@ class ValidationRegions_SubDivisionsOfABCD(FinalBinEdges):
                     final_nTot_SigBkg_dC  = nTot_SigBkg_dB
                     final_nTot_SigBkg_dD  = nTot_SigBkg_dD
        
-        return finalDisc1Key_subDivD, finalDisc2Key_subDivD, finalSigFrac_dA, finalSigFrac_dB, finalSigFrac_dC, finalSigFrac_dD, final_nTot_SigBkg_dA, final_nTot_SigBkg_dB, final_nTot_SigBkg_dC, final_nTot_SigBkg_dD
+        return finalDisc1Key_subDivD, finalDisc2Key_subDivD, finalSigFrac_dA, finalSigFrac_dB, finalSigFrac_dC, finalSigFrac_dD, final_nTot_SigBkg_dA, final_nTot_SigBkg_dB, final_nTot_SigBkg_dC, final_nTot_SigBkg_dD, closureErrsList_subDivD, closureErrUncList_subDivD

--- a/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Classes.py
+++ b/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Classes.py
@@ -169,11 +169,9 @@ class Common_Calculations_Plotters():
                 bkgNjetsPred_A['error'].append(predUnc_A)
 
         if self.channel == '0l':
-            Njets = [
-             7, 8, 9, 10, 11, 12]
+            Njets = [6, 7, 8, 9, 10, 11, 12]
         else:
-            Njets = [
-             7, 8, 9, 10, 11]
+            Njets = [7, 8, 9, 10, 11]
 
         self.plot_ClosureNjets(bkgNjets['A'], bkgNjetsErr['A'], bkgNjetsPred_A['value'], bkgNjetsPred_A['error'], Njets, name)       
     

--- a/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Classes.py
+++ b/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Classes.py
@@ -176,7 +176,7 @@ class Common_Calculations_Plotters():
              7, 8, 9, 10, 11]
 
         self.plot_ClosureNjets(bkgNjets['A'], bkgNjetsErr['A'], bkgNjetsPred_A['value'], bkgNjetsPred_A['error'], Njets, name)       
-
+    
     # --------------------------------------------
     # plot significance as a function of bin edges 
     # --------------------------------------------
@@ -198,9 +198,9 @@ class Common_Calculations_Plotters():
         ax.add_line(l2)
 
         if self.fixed_FinalBinEdges == "fixed":
-             fig.savefig('plots_fixedEdges/%s_%s/%s/%s_Sign_vs_Disc1Disc2%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, Njets, name, self.channel, self.metric), dpi=fig.dpi)
+             fig.savefig('plots_fixedEdges/%s_%s/%s/%s_Sign_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_Sign_vs_Disc1Disc2%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_Sign_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, Njets, name, self.channel, self.metric), dpi=fig.dpi)
 
         plt.close(fig)
 
@@ -225,9 +225,9 @@ class Common_Calculations_Plotters():
         ax.add_line(l2)
 
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_ClosureErr_vs_Disc1Disc2%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_ClosureErr_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_ClosureErr_vs_Disc1Disc2%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_ClosureErr_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
 
         plt.close(fig)
 
@@ -247,9 +247,9 @@ class Common_Calculations_Plotters():
         ax.add_line(l2)
 
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_ClosureErrUnc_vs_Disc1Disc2%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_ClosureErrUnc_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_ClosureErrUnc_vs_Disc1Disc2%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_ClosureErrUnc_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, Njets, name, self.channel, self.metric), dpi=fig.dpi)
 
         plt.close(fig)
 
@@ -277,16 +277,16 @@ class Common_Calculations_Plotters():
         plt.text(0.4, 0.8, '$%.2f < \\bf{Disc.\\;2\\;Edge}$ = %s < %.2f' % (edges[0], disc2Edge, edges[(-1)]), transform=ax.transAxes, fontsize=8)
 
         if self.fixed_FinalBinEdges == "fixed":       
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_InvSign_vs_ClosureErr%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_InvSign_vs_ClosureErr_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_InvSign_vs_ClosureErr%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_InvSign_vs_ClosureErr_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, Njets, name, self.channel, self.metric), dpi=fig.dpi)
 
         plt.close(fig)
 
-    # ----------------------------------
-    # plot Disc1 vs Disc2 in each Region
-    # ----------------------------------
-    def plot_Disc1VsDisc2(self, hist, disc1Edge_ABCD, disc2Edge_ABCD, disc1Edge_bdEF, disc2Edge_cdiGH, tag = ""):
+    # -------------------------------------------------
+    # plot Disc1 vs Disc2 in each Region with all edges
+    # -------------------------------------------------
+    def plot_Disc1VsDisc2(self, hist, disc1Edge_ABCD, disc2Edge_ABCD, disc1Edge_bdEF, disc2Edge_cdiGH, tag = "", name="", col1="", col2=""):
 
         nBins   = hist.GetXaxis().GetNbins()
         nEvents = []; disc1Edges = []; disc2Edges = []
@@ -310,17 +310,17 @@ class Common_Calculations_Plotters():
         ax.text(0.99, 1.04, '%s (13 TeV)' % self.year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
         l1 = ml.Line2D([disc1Edge_ABCD, disc1Edge_ABCD], [0.0, 1.0],   color="darkviolet", linewidth=4, linestyle='solid')
         l2 = ml.Line2D([0.0, 1.0], [disc2Edge_ABCD, disc2Edge_ABCD],   color="darkviolet", linewidth=4, linestyle='solid')
-        l3 = ml.Line2D([disc1Edge_bdEF, disc1Edge_bdEF], [0.0, 1.0],   color="yellow", linewidth=4, linestyle='solid')
-        l4 = ml.Line2D([0.0, 1.0], [disc2Edge_cdiGH, disc2Edge_cdiGH], color="lime",   linewidth=4, linestyle='solid')
+        l3 = ml.Line2D([disc1Edge_bdEF, disc1Edge_bdEF], [0.0, 1.0],   color=col1, linewidth=4, linestyle='solid')
+        l4 = ml.Line2D([0.0, 1.0], [disc2Edge_cdiGH, disc2Edge_cdiGH], color=col2, linewidth=4, linestyle='solid')
         ax.add_line(l1)
         ax.add_line(l2)
         ax.add_line(l3)
         ax.add_line(l4)
 
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_Disc1VsDisc2_%s%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, tag, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_Disc1VsDisc2_%s_Njets%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, tag, self.Njets, name, self.channel), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_Disc1VsDisc2_%s%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, tag, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_Disc1VsDisc2_%s_Njets%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, tag, self.Njets, name, self.channel), dpi=fig.dpi)
         plt.close(fig)
 
     # ---------------------------------------------
@@ -344,9 +344,9 @@ class Common_Calculations_Plotters():
         ax.add_line(l2)
 
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigFracA_vs_Disc1Disc2%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigFracA_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_SigFracA_vs_Disc1Disc2%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_SigFracA_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         plt.close(fig)
 
         # SigFracB vs Disc1Disc2
@@ -365,9 +365,9 @@ class Common_Calculations_Plotters():
         ax.add_line(l2)
 
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigFracB_vs_Disc1Disc2%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigFracB_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_SigFracB_vs_Disc1Disc2%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_SigFracB_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         plt.close(fig)
  
         # SigFracC vs Disc1Disc2
@@ -386,9 +386,9 @@ class Common_Calculations_Plotters():
         ax.add_line(l2)
 
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigFracC_vs_Disc1Disc2%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigFracC_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_SigFracC_vs_Disc1Disc2%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_SigFracC_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         plt.close(fig)
 
         # SigFracD vs Disc1Disc2
@@ -407,15 +407,15 @@ class Common_Calculations_Plotters():
         ax.add_line(l2)
 
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigFracD_vs_Disc1Disc2%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigFracD_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_SigFracD_vs_Disc1Disc2%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_SigFracD_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         plt.close(fig)
 
     # -------------------------------------------------
     # plot SigTotFracs vs Disc1Disc2 in each A, B, C, D
     # ------------------------------------------------- 
-    def plot_SigTotFrac_vsDisc1Disc2(self, nBins, sigTotFracsA, sigTotFracsB, sigTotFracsC, sigTotFracsD, disc1Edges, disc2Edges, c1, c2, minEdge, maxEdge, binWidth):
+    def plot_SigTotFrac_vsDisc1Disc2(self, nBins, sigTotFracsA, sigTotFracsB, sigTotFracsC, sigTotFracsD, disc1Edges, disc2Edges, c1, c2, minEdge, maxEdge, binWidth, name=""):
        
         # SigTotFracA vs Disc1Disc2
         fig = plt.figure()
@@ -426,16 +426,16 @@ class Common_Calculations_Plotters():
         ax.set_ylabel('Disc. 2 Bin Edge')
         ax.text(0.12, 1.05, 'CMS',                transform=ax.transAxes, fontsize=14, fontweight='bold',   va='top', ha='right')
         ax.text(0.33, 1.04, 'Preliminary',        transform=ax.transAxes, fontsize=10, fontstyle='italic',  va='top', ha='right')
-        ax.text(0.99, 1.04, '%s (13 TeV)' % year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
+        ax.text(0.99, 1.04, '%s (13 TeV)' % self.year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
         l1 = ml.Line2D([c1, c1], [0.0, 1.0], color='black', linewidth=2, linestyle='dashed')
         l2 = ml.Line2D([0.0, 1.0], [c2, c2], color='black', linewidth=2, linestyle='dashed')
         ax.add_line(l1)
         ax.add_line(l2)
        
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigTotFracA_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi) 
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigTotFracA_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi) 
         else:
-            fig.savefig('plots/%s_%s/%s/%s_SigTotFracA_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_SigTotFracA_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         plt.close(fig)
         
         # SigTotFracB vs Disc1Disc2
@@ -447,16 +447,16 @@ class Common_Calculations_Plotters():
         ax.set_ylabel('Disc. 2 Bin Edge')
         ax.text(0.12, 1.05, 'CMS',                transform=ax.transAxes, fontsize=14, fontweight='bold',   va='top', ha='right')
         ax.text(0.33, 1.04, 'Preliminary',        transform=ax.transAxes, fontsize=10, fontstyle='italic',  va='top', ha='right')
-        ax.text(0.99, 1.04, '%s (13 TeV)' % year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
+        ax.text(0.99, 1.04, '%s (13 TeV)' % self.year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
         l1 = ml.Line2D([c1, c1], [0.0, 1.0], color='black', linewidth=2, linestyle='dashed')
         l2 = ml.Line2D([0.0, 1.0], [c2, c2], color='black', linewidth=2, linestyle='dashed')
         ax.add_line(l1)
         ax.add_line(l2)
 
         if self.fixed_FinalBinEdges == "fixed":
-             fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigTotFracB_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi)
+             fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigTotFracB_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_SigTotFracB_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_SigTotFracB_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         plt.close(fig)
 
         # SigTotFracC vs Disc1Disc2
@@ -468,16 +468,16 @@ class Common_Calculations_Plotters():
         ax.set_ylabel('Disc. 2 Bin Edge')
         ax.text(0.12, 1.05, 'CMS',                transform=ax.transAxes, fontsize=14, fontweight='bold',   va='top', ha='right')
         ax.text(0.33, 1.04, 'Preliminary',        transform=ax.transAxes, fontsize=10, fontstyle='italic',  va='top', ha='right')
-        ax.text(0.99, 1.04, '%s (13 TeV)' % year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
+        ax.text(0.99, 1.04, '%s (13 TeV)' % self.year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
         l1 = ml.Line2D([c1, c1], [0.0, 1.0], color='black', linewidth=2, linestyle='dashed')
         l2 = ml.Line2D([0.0, 1.0], [c2, c2], color='black', linewidth=2, linestyle='dashed')
         ax.add_line(l1)
         ax.add_line(l2)
 
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigTotFracC_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigTotFracC_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_SigTotFracC_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_SigTotFracC_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         plt.close(fig)
 
         # SigTotFracD vs Disc1Disc2
@@ -489,22 +489,22 @@ class Common_Calculations_Plotters():
         ax.set_ylabel('Disc. 2 Bin Edge')
         ax.text(0.12, 1.05, 'CMS',                transform=ax.transAxes, fontsize=14, fontweight='bold',   va='top', ha='right')
         ax.text(0.33, 1.04, 'Preliminary',        transform=ax.transAxes, fontsize=10, fontstyle='italic',  va='top', ha='right')
-        ax.text(0.99, 1.04, '%s (13 TeV)' % year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
+        ax.text(0.99, 1.04, '%s (13 TeV)' % self.year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
         l1 = ml.Line2D([c1, c1], [0.0, 1.0], color='black', linewidth=2, linestyle='dashed')
         l2 = ml.Line2D([0.0, 1.0], [c2, c2], color='black', linewidth=2, linestyle='dashed')
         ax.add_line(l1)
         ax.add_line(l2)
 
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigTotFracD_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_SigTotFracD_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_SigTotFracD_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_SigTotFracD_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         plt.close(fig)
 
     # -------------------------------------------------
     # plot BkgTotFracs vs Disc1Disc2 in each A, B, C, D
     # -------------------------------------------------
-    def plot_BkgTotFrac_vsDisc1Disc2(self, nBins, bkgTotFracsA, bkgTotFracsB, bkgTotFracsC, bkgTotFracsD, disc1Edges, disc2Edges, c1, c2, minEdge, maxEdge, binWidth):
+    def plot_BkgTotFrac_vsDisc1Disc2(self, nBins, bkgTotFracsA, bkgTotFracsB, bkgTotFracsC, bkgTotFracsD, disc1Edges, disc2Edges, c1, c2, minEdge, maxEdge, binWidth, name=""):
         
         # BkgTotFracA vs Disc1Disc2
         fig = plt.figure()
@@ -515,16 +515,16 @@ class Common_Calculations_Plotters():
         ax.set_ylabel('Disc. 2 Bin Edge')
         ax.text(0.12, 1.05, 'CMS',                transform=ax.transAxes, fontsize=14, fontweight='bold',   va='top', ha='right')
         ax.text(0.33, 1.04, 'Preliminary',        transform=ax.transAxes, fontsize=10, fontstyle='italic',  va='top', ha='right')
-        ax.text(0.99, 1.04, '%s (13 TeV)' % year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
+        ax.text(0.99, 1.04, '%s (13 TeV)' % self.year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
         l1 = ml.Line2D([c1, c1], [0.0, 1.0], color='black', linewidth=2, linestyle='dashed')
         l2 = ml.Line2D([0.0, 1.0], [c2, c2], color='black', linewidth=2, linestyle='dashed')
         ax.add_line(l1)
         ax.add_line(l2)
 
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_BkgTotFracA_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_BkgTotFracA_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_BkgTotFracA_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_BkgTotFracA_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         plt.close(fig)
 
         # BkgTotFracB vs Disc1Disc2
@@ -536,16 +536,16 @@ class Common_Calculations_Plotters():
         ax.set_ylabel('Disc. 2 Bin Edge')
         ax.text(0.12, 1.05, 'CMS',                transform=ax.transAxes, fontsize=14, fontweight='bold',   va='top', ha='right')
         ax.text(0.33, 1.04, 'Preliminary',        transform=ax.transAxes, fontsize=10, fontstyle='italic',  va='top', ha='right')
-        ax.text(0.99, 1.04, '%s (13 TeV)' % year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
+        ax.text(0.99, 1.04, '%s (13 TeV)' % self.year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
         l1 = ml.Line2D([c1, c1], [0.0, 1.0], color='black', linewidth=2, linestyle='dashed')
         l2 = ml.Line2D([0.0, 1.0], [c2, c2], color='black', linewidth=2, linestyle='dashed')
         ax.add_line(l1)
         ax.add_line(l2)
 
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_BkgTotFracB_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_BkgTotFracB_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_BkgTotFracB_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_BkgTotFracB_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         plt.close(fig)
 
         # BkgTotFracC vs Disc1Disc2
@@ -557,16 +557,16 @@ class Common_Calculations_Plotters():
         ax.set_ylabel('Disc. 2 Bin Edge')
         ax.text(0.12, 1.05, 'CMS',                transform=ax.transAxes, fontsize=14, fontweight='bold',   va='top', ha='right')
         ax.text(0.33, 1.04, 'Preliminary',        transform=ax.transAxes, fontsize=10, fontstyle='italic',  va='top', ha='right')
-        ax.text(0.99, 1.04, '%s (13 TeV)' % year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
+        ax.text(0.99, 1.04, '%s (13 TeV)' % self.year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
         l1 = ml.Line2D([c1, c1], [0.0, 1.0], color='black', linewidth=2, linestyle='dashed')
         l2 = ml.Line2D([0.0, 1.0], [c2, c2], color='black', linewidth=2, linestyle='dashed')
         ax.add_line(l1)
         ax.add_line(l2)
 
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_BkgTotFracC_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_BkgTotFracC_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_BkgTotFracC_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_BkgTotFracC_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         plt.close(fig)
 
         # BkgTotFracD vs Disc1Disc2
@@ -578,16 +578,16 @@ class Common_Calculations_Plotters():
         ax.set_ylabel('Disc. 2 Bin Edge')
         ax.text(0.12, 1.05, 'CMS',                transform=ax.transAxes, fontsize=14, fontweight='bold',   va='top', ha='right')
         ax.text(0.33, 1.04, 'Preliminary',        transform=ax.transAxes, fontsize=10, fontstyle='italic',  va='top', ha='right')
-        ax.text(0.99, 1.04, '%s (13 TeV)' % year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
+        ax.text(0.99, 1.04, '%s (13 TeV)' % self.year, transform=ax.transAxes, fontsize=10, fontweight='normal', va='top', ha='right')
         l1 = ml.Line2D([c1, c1], [0.0, 1.0], color='black', linewidth=2, linestyle='dashed')
         l2 = ml.Line2D([0.0, 1.0], [c2, c2], color='black', linewidth=2, linestyle='dashed')
         ax.add_line(l1)
         ax.add_line(l2)
 
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_BkgTotFracD_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_BkgTotFracD_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_BkgTotFracD_vs_Disc1Disc2%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, self.channel), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_BkgTotFracD_vs_Disc1Disc2_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         plt.close(fig)
 
     # ------------------------------------------------
@@ -656,9 +656,9 @@ class Common_Calculations_Plotters():
         fig.tight_layout()
 
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_%s_Slices_Disc%d%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, tag, disc, Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_%s_Slices_Disc%d_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, tag, disc, Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:        
-            fig.savefig('plots/%s_%s/%s/%s_%s_Slices_Disc%d%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, tag, disc, Njets, name, self.channel, self.metric), dpi=fig.dpi)   
+            fig.savefig('plots/%s_%s/%s/%s_%s_Slices_Disc%d_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, tag, disc, Njets, name, self.channel, self.metric), dpi=fig.dpi)   
 
         plt.close(fig)
 
@@ -691,9 +691,9 @@ class Common_Calculations_Plotters():
         fig.tight_layout()
 
         if self.fixed_FinalBinEdges == "fixed":
-            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_%s_Slices_Disc%d%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, tag, disc, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots_fixedEdges/%s_%s/%s/%s_%s_Slices_Disc%d_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, tag, disc, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
         else:
-            fig.savefig('plots/%s_%s/%s/%s_%s_Slices_Disc%d%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, tag, disc, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
+            fig.savefig('plots/%s_%s/%s/%s_%s_Slices_Disc%d_Njets%s_%s_%s_%s.pdf' % (self.model, self.mass, self.channel, self.year, tag, disc, self.Njets, name, self.channel, self.metric), dpi=fig.dpi)
 
         plt.close(fig)
 
@@ -1430,3 +1430,220 @@ class ValidationRegions(FinalBinEdges):
 
         return finalDisc1Key_cdiGH, finalDisc2Key_cdiGH, disc1KeyOut_cdiGH, disc2KeyOut_cdiGH, closureErrsList_cdiGH, closureErrUncList_cdiGH, weighted_Sig_c, weighted_Bkg_c, weighted_SigUnc_c, weighted_BkgUnc_c, sigFracsc, sigFracsdi, sigFracsG, sigFracsH, sigFracsErrc, sigFracsErrdi, sigFracsErrG, sigFracsErrH, finalSigFracc, finalSigFracdi, finalSigFracG, finalSigFracH, nEvents_cdi, nEvents_GH
 
+
+
+class ValidationRegions_SubDivisionsOfABCD(FinalBinEdges):
+
+    def __init__(self, year, model, mass, channel, metric, fixed_FinalBinEdges, Njets = -1):
+        self.Njets   = Njets
+        self.year    = year
+        self.model   = model
+        self.mass    = mass
+        self.channel = channel
+        self.metric  = metric
+        self.fixed_FinalBinEdges = fixed_FinalBinEdges
+
+    def __del__(self):
+        del self.Njets
+        del self.year
+        del self.model
+        del self.mass
+        del self.channel
+        del self.metric
+        del self.fixed_FinalBinEdges
+
+    # -------------------------------------------------------
+    # get signal and background histograms' counts
+    #   -- count both signal and background events separately 
+    #   -- in sub-division of D region
+    # -------------------------------------------------------
+    def count_Events_inSubDivisionsOfABCD(self, histBkg, histSig, finalDisc1Edge, finalDisc2Edge):
+
+        # get variables for another validation regions which are sub-division of each A,B,C,D region
+        lastXBin   = histBkg.GetNbinsX(); nXBins = range(2, lastXBin+1)
+        lastYBin   = histBkg.GetNbinsY(); nYBins = range(2, lastYBin+1)
+        finalDisc1 = histBkg.GetXaxis().FindBin(float(finalDisc1Edge))
+        finalDisc2 = histBkg.GetXaxis().FindBin(float(finalDisc2Edge))
+
+        # for A region
+        a_xmin = finalDisc1; a_xmax = lastXBin; nA_xBins = range(a_xmin, a_xmax)
+        a_ymin = finalDisc2; a_ymax = lastYBin; nA_yBins = range(a_ymin, a_ymax)
+
+        # for B region
+        b_xmin = 1;          b_xmax = finalDisc1; nB_xBins = range(b_xmin, b_xmax)
+        b_ymin = finalDisc2; b_ymax = lastYBin;   nB_yBins = range(b_ymin, b_ymax)
+
+        # for C region
+        c_xmin = finalDisc1; c_xmax = lastXBin;   nC_xBins = range(c_xmin, c_xmax)
+        c_ymin = 1;          c_ymax = finalDisc2; nC_yBins = range(c_ymin, c_ymax)
+
+        # for D region
+        d_xmin = 1; d_xmax = finalDisc1; nD_xBins = range(d_xmin, d_xmax)
+        d_ymin = 1; d_ymax = finalDisc2; nD_yBins = range(d_ymin, d_ymax)
+
+        nTotSigCount = {
+            #"nSigEvents_aA"    : {}, "nSigEvents_aB"    : {}, "nSigEvents_aC"    : {}, "nSigEvents_aD"    : {},
+            #"nSigEvents_bA"    : {}, "nSigEvents_bB"    : {}, "nSigEvents_bC"    : {}, "nSigEvents_bD"    : {},
+            #"nSigEvents_cA"    : {}, "nSigEvents_cB"    : {}, "nSigEvents_cC"    : {}, "nSigEvents_cD"    : {},
+            #"nSigEvents_dA"    : {}, "nSigEvents_dB"    : {}, "nSigEvents_dC"    : {}, "nSigEvents_dD"    : {},           
+            #"nSigEventsErr_aA" : {}, "nSigEventsErr_aB" : {}, "nSigEventsErr_aC" : {}, "nSigEventsErr_aD" : {},
+            #"nSigEventsErr_bA" : {}, "nSigEventsErr_bB" : {}, "nSigEventsErr_bC" : {}, "nSigEventsErr_bD" : {},
+            #"nSigEventsErr_cA" : {}, "nSigEventsErr_cB" : {}, "nSigEventsErr_cC" : {}, "nSigEventsErr_cD" : {},
+            #"nSigEventsErr_dA" : {}, "nSigEventsErr_dB" : {}, "nSigEventsErr_dC" : {}, "nSigEventsErr_dD" : {},
+
+            "nSigEvents_A" : {},    "nSigEvents_B" : {},    "nSigEvents_C" : {},    "nSigEvents_D" : {},
+            "nSigEventsErr_A" : {}, "nSigEventsErr_B" : {}, "nSigEventsErr_C" : {}, "nSigEventsErr_D" : {}
+        }
+
+        nTotBkgCount = {
+            #"nBkgEvents_aA"    : {}, "nBkgEvents_aB"    : {}, "nBkgEvents_aC"    : {}, "nBkgEvents_aD"    : {},
+            #"nBkgEvents_bA"    : {}, "nBkgEvents_bB"    : {}, "nBkgEvents_bC"    : {}, "nBkgEvents_bD"    : {},
+            #"nBkgEvents_cA"    : {}, "nBkgEvents_cB"    : {}, "nBkgEvents_cC"    : {}, "nBkgEvents_cD"    : {},
+            #"nBkgEvents_dA"    : {}, "nBkgEvents_dB"    : {}, "nBkgEvents_dC"    : {}, "nBkgEvents_dD"    : {}, 
+            #"nBkgEventsErr_aA" : {}, "nBkgEventsErr_aB" : {}, "nBkgEventsErr_aC" : {}, "nBkgEventsErr_aD" : {},
+            #"nBkgEventsErr_bA" : {}, "nBkgEventsErr_bB" : {}, "nBkgEventsErr_bC" : {}, "nBkgEventsErr_bD" : {},
+            #"nBkgEventsErr_cA" : {}, "nBkgEventsErr_cB" : {}, "nBkgEventsErr_cC" : {}, "nBkgEventsErr_cD" : {},
+            #"nBkgEventsErr_dA" : {}, "nBkgEventsErr_dB" : {}, "nBkgEventsErr_dC" : {}, "nBkgEventsErr_dD" : {},
+
+            "nBkgEvents_A" : {},    "nBkgEvents_B" : {},    "nBkgEvents_C" : {},    "nBkgEvents_D" : {},
+            "nBkgEventsErr_A" : {}, "nBkgEventsErr_B" : {}, "nBkgEventsErr_C" : {}, "nBkgEventsErr_D" : {}
+        }
+
+        # loop over the x bins
+        for d_xBin in nD_xBins:
+
+            xLowBinEdge = histBkg.GetXaxis().GetBinCenter(d_xBin)
+            xBinKey   = "%.3f"%xLowBinEdge
+
+            if xBinKey not in nTotSigCount["nSigEventsErr_A"]:
+                nTotSigCount["nSigEvents_A"][xBinKey] = {}; nTotSigCount["nSigEventsErr_A"][xBinKey] = {}
+                nTotSigCount["nSigEvents_B"][xBinKey] = {}; nTotSigCount["nSigEventsErr_B"][xBinKey] = {}
+                nTotSigCount["nSigEvents_C"][xBinKey] = {}; nTotSigCount["nSigEventsErr_C"][xBinKey] = {}
+                nTotSigCount["nSigEvents_D"][xBinKey] = {}; nTotSigCount["nSigEventsErr_D"][xBinKey] = {}
+
+            if xBinKey not in nTotBkgCount["nBkgEventsErr_A"]:
+                nTotBkgCount["nBkgEvents_A"][xBinKey] = {}; nTotBkgCount["nBkgEventsErr_A"][xBinKey] = {}
+                nTotBkgCount["nBkgEvents_B"][xBinKey] = {}; nTotBkgCount["nBkgEventsErr_B"][xBinKey] = {}
+                nTotBkgCount["nBkgEvents_C"][xBinKey] = {}; nTotBkgCount["nBkgEventsErr_C"][xBinKey] = {}
+                nTotBkgCount["nBkgEvents_D"][xBinKey] = {}; nTotBkgCount["nBkgEventsErr_D"][xBinKey] = {}
+
+            # loop over the y bins
+            for d_yBin in nD_yBins:
+
+                yLowBinEdge = histBkg.GetYaxis().GetBinCenter(d_yBin)
+                yBinKey   = "%.3f"%yLowBinEdge
+
+                if yBinKey not in nTotSigCount["nSigEventsErr_A"]:
+                    nTotSigCount["nSigEvents_A"][xBinKey][yBinKey] = 0.0; nTotSigCount["nSigEventsErr_A"][xBinKey][yBinKey] = 0.0
+                    nTotSigCount["nSigEvents_B"][xBinKey][yBinKey] = 0.0; nTotSigCount["nSigEventsErr_B"][xBinKey][yBinKey] = 0.0
+                    nTotSigCount["nSigEvents_C"][xBinKey][yBinKey] = 0.0; nTotSigCount["nSigEventsErr_C"][xBinKey][yBinKey] = 0.0
+                    nTotSigCount["nSigEvents_D"][xBinKey][yBinKey] = 0.0; nTotSigCount["nSigEventsErr_D"][xBinKey][yBinKey] = 0.0
+
+                if yBinKey not in nTotBkgCount["nBkgEventsErr_A"]:
+                    nTotBkgCount["nBkgEvents_A"][xBinKey][yBinKey] = 0.0; nTotBkgCount["nBkgEventsErr_A"][xBinKey][yBinKey] = 0.0
+                    nTotBkgCount["nBkgEvents_B"][xBinKey][yBinKey] = 0.0; nTotBkgCount["nBkgEventsErr_B"][xBinKey][yBinKey] = 0.0
+                    nTotBkgCount["nBkgEvents_C"][xBinKey][yBinKey] = 0.0; nTotBkgCount["nBkgEventsErr_C"][xBinKey][yBinKey] = 0.0
+                    nTotBkgCount["nBkgEvents_D"][xBinKey][yBinKey] = 0.0; nTotBkgCount["nBkgEventsErr_D"][xBinKey][yBinKey] = 0.0
+
+                # count signal and background events and errors in bin edges
+                nSigEventsErr_dA = ROOT.Double(0.0); nSigEventsErr_dB = ROOT.Double(0.0); nSigEventsErr_dC = ROOT.Double(0.0); nSigEventsErr_dD = ROOT.Double(0.0)
+                nBkgEventsErr_dA = ROOT.Double(0.0); nBkgEventsErr_dB = ROOT.Double(0.0); nBkgEventsErr_dC = ROOT.Double(0.0); nBkgEventsErr_dD = ROOT.Double(0.0)
+                nSigEvents_dA = ( histSig.IntegralAndError(d_xBin, finalDisc1, d_yBin, finalDisc2, nSigEventsErr_dA) )
+                nSigEvents_dB = ( histSig.IntegralAndError(1,      d_xBin,     d_yBin, finalDisc2, nSigEventsErr_dB) )
+                nSigEvents_dC = ( histSig.IntegralAndError(d_xBin, finalDisc1, 1,      d_yBin,     nSigEventsErr_dC) )
+                nSigEvents_dD = ( histSig.IntegralAndError(1,      d_xBin,     1,      d_yBin,     nSigEventsErr_dD) )
+                nBkgEvents_dA = ( histBkg.IntegralAndError(d_xBin, finalDisc1, d_yBin, finalDisc2, nBkgEventsErr_dA) )
+                nBkgEvents_dB = ( histBkg.IntegralAndError(1,      d_xBin,     d_yBin, finalDisc2, nBkgEventsErr_dB) )
+                nBkgEvents_dC = ( histBkg.IntegralAndError(d_xBin, finalDisc1, 1,      d_yBin,     nBkgEventsErr_dC) )
+                nBkgEvents_dD = ( histBkg.IntegralAndError(1,      d_xBin,     1,      d_yBin,     nBkgEventsErr_dD) )
+
+                nTotSigCount["nSigEvents_A"][xBinKey][yBinKey] = nSigEvents_dA; nTotSigCount["nSigEventsErr_A"][xBinKey][yBinKey] = nSigEventsErr_dA
+                nTotSigCount["nSigEvents_B"][xBinKey][yBinKey] = nSigEvents_dB; nTotSigCount["nSigEventsErr_B"][xBinKey][yBinKey] = nSigEventsErr_dB
+                nTotSigCount["nSigEvents_C"][xBinKey][yBinKey] = nSigEvents_dC; nTotSigCount["nSigEventsErr_C"][xBinKey][yBinKey] = nSigEventsErr_dC
+                nTotSigCount["nSigEvents_D"][xBinKey][yBinKey] = nSigEvents_dD; nTotSigCount["nSigEventsErr_D"][xBinKey][yBinKey] = nSigEventsErr_dD
+
+                nTotBkgCount["nBkgEvents_A"][xBinKey][yBinKey] = nBkgEvents_dA; nTotBkgCount["nBkgEventsErr_A"][xBinKey][yBinKey] = nBkgEventsErr_dA
+                nTotBkgCount["nBkgEvents_B"][xBinKey][yBinKey] = nBkgEvents_dB; nTotBkgCount["nBkgEventsErr_B"][xBinKey][yBinKey] = nBkgEventsErr_dB
+                nTotBkgCount["nBkgEvents_C"][xBinKey][yBinKey] = nBkgEvents_dC; nTotBkgCount["nBkgEventsErr_C"][xBinKey][yBinKey] = nBkgEventsErr_dC
+                nTotBkgCount["nBkgEvents_D"][xBinKey][yBinKey] = nBkgEvents_dD; nTotBkgCount["nBkgEventsErr_D"][xBinKey][yBinKey] = nBkgEventsErr_dD
+
+        return nTotSigCount, nTotBkgCount
+
+    # ------------------------------------------------------
+    # get the final bin edges for another validation regions
+    #   -- Validation region sub-division A
+    #   -- Validation region sub-division B
+    #   -- Validation region sub-division C
+    #   -- Validation region sub-division D
+    # ------------------------------------------------------
+    def get_ValidationEdges_SubDivisionsOfABCD(self, nTotSigCount, nTotBkgCount, finalDisc1Edge, finalDisc2Edge):
+
+        disc1KeyOut_subDivD = [];  disc2KeyOut_subDivD = [];  finalDisc1Key_subDivD = -1.0; finalDisc2Key_subDivD = -1.0; 
+        finalSigFrac_dA     = 0.0; finalSigFrac_dB     = 0.0; finalSigFrac_dC       = 0.0;  finalSigFrac_dC       = 0.0;  
+        nEvents_dAC         = 0.0; nEvents_dBD         = 0.0
+        
+        # loop over the disc1 and disc2 to get any possible combination of them
+        for disc1Key, disc2s in nTotBkgCount["nBkgEvents_A"].items():
+            
+            for disc2Key, nEvents in disc2s.items():
+
+                # number of signal and background events in aech A, B, C, D region
+                nSigEvents_dA = nTotSigCount["nSigEvents_A"][disc1Key][disc2Key]; nBkgEvents_dA = nTotBkgCount["nBkgEvents_A"][disc1Key][disc2Key] 
+                nSigEvents_dB = nTotSigCount["nSigEvents_B"][disc1Key][disc2Key]; nBkgEvents_dB = nTotBkgCount["nBkgEvents_B"][disc1Key][disc2Key]
+                nSigEvents_dC = nTotSigCount["nSigEvents_C"][disc1Key][disc2Key]; nBkgEvents_dC = nTotBkgCount["nBkgEvents_C"][disc1Key][disc2Key]
+                nSigEvents_dD = nTotSigCount["nSigEvents_D"][disc1Key][disc2Key]; nBkgEvents_dD = nTotBkgCount["nBkgEvents_D"][disc1Key][disc2Key]
+            
+                nSigEventsErr_dA = nTotSigCount["nSigEventsErr_A"][disc1Key][disc2Key]; nBkgEventsErr_dA = nTotBkgCount["nBkgEventsErr_A"][disc1Key][disc2Key]
+                nSigEventsErr_dB = nTotSigCount["nSigEventsErr_B"][disc1Key][disc2Key]; nBkgEventsErr_dB = nTotBkgCount["nBkgEventsErr_B"][disc1Key][disc2Key]
+                nSigEventsErr_dC = nTotSigCount["nSigEventsErr_C"][disc1Key][disc2Key]; nBkgEventsErr_dC = nTotBkgCount["nBkgEventsErr_C"][disc1Key][disc2Key]
+                nSigEventsErr_dD = nTotSigCount["nSigEventsErr_D"][disc1Key][disc2Key]; nBkgEventsErr_dD = nTotBkgCount["nBkgEventsErr_D"][disc1Key][disc2Key]  
+
+                # Signal fractions and fraction errors in each dA, dB, dC, dD  region
+                nTot_SigBkg_dA = nSigEvents_dA + nBkgEvents_dA
+                nTot_SigBkg_dB = nSigEvents_dB + nBkgEvents_dB
+                nTot_SigBkg_dC = nSigEvents_dC + nBkgEvents_dC
+                nTot_SigBkg_dD = nSigEvents_dD + nBkgEvents_dD
+
+                nTot_SigBkgErr_dA = nSigEventsErr_dA + nBkgEventsErr_dA
+                nTot_SigBkgErr_dB = nSigEventsErr_dB + nBkgEventsErr_dB
+                nTot_SigBkgErr_dC = nSigEventsErr_dC + nBkgEventsErr_dC
+                nTot_SigBkgErr_dD = nSigEventsErr_dD + nBkgEventsErr_dD
+    
+                tempSigFracs_dA    = -1.0; tempSigFracs_dB    = -1.0; tempSigFracs_dC    = -1.0; tempSigFracs_dD    = -1.0
+                tempSigFracsErr_dA = -1.0; tempSigFracsErr_dB = -1.0; tempSigFracsErr_dC = -1.0; tempSigFracsErr_dD = -1.0   
+ 
+                if nTot_SigBkg_dA > 0.0 and nTot_SigBkgErr_dA > 0.0: 
+                    tempSigFracs_dA    = nSigEvents_dA / nTot_SigBkg_dA
+                    tempSigFracsErr_dA = nSigEventsErr_dA / nTot_SigBkgErr_dA
+            
+                if nTot_SigBkg_dB > 0.0 and nTot_SigBkgErr_dB > 0.0:
+                    tempSigFracs_dB    = nSigEvents_dB / nTot_SigBkg_dB
+                    tempSigFracsErr_dB = nSigEventsErr_dB / nTot_SigBkgErr_dB
+
+                if nTot_SigBkg_dC > 0.0 and nTot_SigBkgErr_dC > 0.0:
+                    tempSigFracs_dC    = nSigEvents_dC / nTot_SigBkg_dC
+                    tempSigFracsErr_dC = nSigEventsErr_dC / nTot_SigBkgErr_dC
+
+                if nTot_SigBkg_dD > 0.0 and nTot_SigBkgErr_dD > 0.0:
+                    tempSigFracs_dD    = nSigEvents_dD / nTot_SigBkg_dD
+                    tempSigFracsErr_dD = nSigEventsErr_dD / nTot_SigBkgErr_dD
+
+                # get the closure error and closure error unc. to plot variable vs disc as 1D 
+                tempClosureErr = -999.0; tempClosureErrUnc = -999.0;
+                if nBkgEvents_dA > 0.0 and nBkgEvents_dD > 0.0: 
+                    tempClosureErr, tempClosureErrUnc = self.cal_ClosureError(nBkgEvents_dA, nBkgEvents_dB, nBkgEvents_dC, nBkgEvents_dD, nBkgEventsErr_dA, nBkgEventsErr_dB, nBkgEventsErr_dC, nBkgEventsErr_dD)
+
+                # get the final edges
+                if abs( ( float(disc1Key) - (float(finalDisc1Edge) / 2.0) ) ) < 0.01 and abs( ( float(disc2Key) - (float(finalDisc2Edge) / 2.0) ) ) < 0.01:
+                    finalDisc1Key_subDivD = disc1Key
+                    finalDisc2Key_subDivD = disc2Key
+                    finalSigFrac_dA       = tempSigFracs_dA
+                    finalSigFrac_dB       = tempSigFracs_dB
+                    finalSigFrac_dC       = tempSigFracs_dC
+                    finalSigFrac_dD       = tempSigFracs_dD
+                    final_nTot_SigBkg_dA  = nTot_SigBkg_dA                   
+                    final_nTot_SigBkg_dB  = nTot_SigBkg_dC
+                    final_nTot_SigBkg_dC  = nTot_SigBkg_dB
+                    final_nTot_SigBkg_dD  = nTot_SigBkg_dD
+       
+        return finalDisc1Key_subDivD, finalDisc2Key_subDivD, finalSigFrac_dA, finalSigFrac_dB, finalSigFrac_dC, finalSigFrac_dD, final_nTot_SigBkg_dA, final_nTot_SigBkg_dB, final_nTot_SigBkg_dC, final_nTot_SigBkg_dD

--- a/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Plotters.py
+++ b/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Plotters.py
@@ -282,7 +282,7 @@ def main():
         # -----------------------------------------------------
         val_SubDivisionsOfABCD = ValidationRegions_SubDivisionsOfABCD(args.year, args.model, args.mass, args.channel, args.metric, args.edges, njet)
         nTotSigCount, nTotBkgCount = val_SubDivisionsOfABCD.count_Events_inSubDivisionsOfABCD(histBkg, histSig, float(finalDisc1Key), float(finalDisc2Key))
-        finalDisc1Key_subDivD, finalDisc2Key_subDivD, finalSigFrac_dA, finalSigFrac_dB, finalSigFrac_dC, finalSigFrac_dD, final_nTot_SigBkg_dA, final_nTot_SigBkg_dB, final_nTot_SigBkg_dC, final_nTot_SigBkg_dD = val_SubDivisionsOfABCD.get_ValidationEdges_SubDivisionsOfABCD(nTotSigCount, nTotBkgCount, float(finalDisc1Key), float(finalDisc2Key)) 
+        finalDisc1Key_subDivD, finalDisc2Key_subDivD, finalSigFrac_dA, finalSigFrac_dB, finalSigFrac_dC, finalSigFrac_dD, final_nTot_SigBkg_dA, final_nTot_SigBkg_dB, final_nTot_SigBkg_dC, final_nTot_SigBkg_dD, closureErrsList_subDivD, closureErrUncList_subDivD = val_SubDivisionsOfABCD.get_ValidationEdges_SubDivisionsOfABCD(nTotSigCount, nTotBkgCount, float(finalDisc1Key), float(finalDisc2Key)) 
 
         # get the lists to make all closure plots 
         final_subDivD_Edges.append((finalDisc1Key_subDivD, finalDisc2Key_subDivD))
@@ -294,8 +294,13 @@ def main():
         d.write("\hline")
         d.write("\n")
 
+        # plot variable vs disc as 1D 
+        plotter.plot_VarVsDisc(closureErrsList_subDivD, closureErrUncList_subDivD, disc1KeyOut, disc2KeyOut, binWidth/2.0, 1.0, "Sub-Division D Closure", "Closure", 1, njet, name = "Val_SubDivD")
+        plotter.plot_VarVsDisc(closureErrsList_subDivD, closureErrUncList_subDivD, disc1KeyOut, disc2KeyOut, binWidth/2.0, 1.0, "Sub-Division D Closure", "Closure", 2, njet, name = "Val_SubDivD")
 
+        # ------------------------------------
         # plot Disc1s vs Disc2s with all edges
+        # ------------------------------------
         if args.metric == "New":
             plotter.plot_Disc1VsDisc2(histSig, float(finalDisc1Key), float(finalDisc2Key), float(finalDisc1Key_bdEF), float(finalDisc2Key_cdiGH), tag = "RPV550", name = "Val_BD_CD", col1="yellow", col2="lime")
             plotter.plot_Disc1VsDisc2(histBkg, float(finalDisc1Key), float(finalDisc2Key), float(finalDisc1Key_bdEF), float(finalDisc2Key_cdiGH), tag = "TT",     name = "Val_BD_CD", col1="yellow", col2="lime")

--- a/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Plotters.py
+++ b/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Plotters.py
@@ -268,7 +268,7 @@ def main():
         # -----------------------------------------------------
         val_SubDivisionsOfABCD = ValidationRegions_SubDivisionsOfABCD(args.year, args.model, args.mass, args.channel, args.metric, args.edges, njet)
         nTotSigCount, nTotBkgCount = val_SubDivisionsOfABCD.count_Events_inSubDivisionsOfABCD(histBkg, histSig, float(finalDisc1Key), float(finalDisc2Key))
-        finalDisc1Key_subDivD, finalDisc2Key_subDivD, finalSigFrac_dA, finalSigFrac_dB, finalSigFrac_dC, finalSigFrac_dD, final_nTot_SigBkg_dA, final_nTot_SigBkg_dB, final_nTot_SigBkg_dC, final_nTot_SigBkg_dD, closureErrsList_subDivD, closureErrUncList_subDivD = val_SubDivisionsOfABCD.get_ValidationEdges_SubDivisionsOfABCD(nTotSigCount, nTotBkgCount, float(finalDisc1Key), float(finalDisc2Key)) 
+        finalDisc1Key_subDivD, finalDisc2Key_subDivD, finalSigFrac_dA, finalSigFrac_dB, finalSigFrac_dC, finalSigFrac_dD, final_nTot_SigBkg_dA, final_nTot_SigBkg_dB, final_nTot_SigBkg_dC, final_nTot_SigBkg_dD, closureErrsList_subDivD, closureErrUncList_subDivD, disc1KeyOut_subDivD, disc2KeyOut_subDivD = val_SubDivisionsOfABCD.get_ValidationEdges_SubDivisionsOfABCD(nTotSigCount, nTotBkgCount, float(finalDisc1Key), float(finalDisc2Key)) 
 
         # get the lists to make all closure plots 
         final_subDivD_Edges.append((finalDisc1Key_subDivD, finalDisc2Key_subDivD))
@@ -281,8 +281,8 @@ def main():
         d.write("\n")
 
         # plot variable vs disc as 1D 
-        plotter.plot_VarVsDisc(closureErrsList_subDivD, closureErrUncList_subDivD, disc1KeyOut, disc2KeyOut, binWidth/2.0, 1.0, "Sub-Division D Closure", "Closure", 1, njet, name = "Val_SubDivD")
-        plotter.plot_VarVsDisc(closureErrsList_subDivD, closureErrUncList_subDivD, disc1KeyOut, disc2KeyOut, binWidth/2.0, 1.0, "Sub-Division D Closure", "Closure", 2, njet, name = "Val_SubDivD")
+        plotter.plot_VarVsDisc(closureErrsList_subDivD, closureErrUncList_subDivD, disc1KeyOut_subDivD, disc2KeyOut_subDivD, binWidth/2.0, 1.0, "Sub-Division D Closure", "Closure", 1, njet, name = "Val_SubDivD")
+        plotter.plot_VarVsDisc(closureErrsList_subDivD, closureErrUncList_subDivD, disc1KeyOut_subDivD, disc2KeyOut_subDivD, binWidth/2.0, 1.0, "Sub-Division D Closure", "Closure", 2, njet, name = "Val_SubDivD")
 
         # ------------------------------------
         # plot Disc1s vs Disc2s with all edges

--- a/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Plotters.py
+++ b/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Plotters.py
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 # mpl version is 2.2.5
 
 from matplotlib.colors import LogNorm
-from DoubleDisCo_BinEdges_Classes import Common_Calculations_Plotters,FinalBinEdges,ValidationRegions 
+from DoubleDisCo_BinEdges_Classes import Common_Calculations_Plotters, FinalBinEdges, ValidationRegions, ValidationRegions_SubDivisionsOfABCD 
 
 
 def main():
@@ -56,37 +56,40 @@ def main():
 
     # for 0-lepton 
     if args.channel == "0l":
-        histNames = "h_DoubleDisCo_disc1_disc2_0l"
+        histNames = "h_DoubleDisCo_disc1_disc2_0l_Njets"
         njets = [
-            "_Njets6",
-            "_Njets7",
-            "_Njets8",
-            "_Njets9",
-            "_Njets10",
-            "_Njets11",
-            "_Njets12",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
         ]
 
     # for 1-lepton
     else:
-        histNames = "h_DoubleDisCo_disc1_disc2_1l"
+        histNames = "h_DoubleDisCo_disc1_disc2_1l_Njets"
         njets = [
-            "_Njets7",
-            "_Njets8",
-            "_Njets9",
-            "_Njets10",
-            "_Njets11",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
         ]
 
     # initialize the things
-    finalBinEdges           = []; bdEF_FinalEdges         = []; cdiGH_FinalEdges         = []
-    final_nTotBkgCount_ABCD = []; final_nTotBkgCount_bdEF = []; final_nTotBkgCount_cdiGH = []
+    finalBinEdges       = []; final_nTotBkgCount_ABCD  = [] 
+    bdEF_FinalEdges     = []; final_nTotBkgCount_bdEF  = []
+    cdiGH_FinalEdges    = []; final_nTotBkgCount_cdiGH = []
+    final_subDivD_Edges = []; final_nTotBkgCount       = []
+
 
     # ------------------
     # make all tex files
     # -----------------
     # put all latest bin edges to tex file
-    h = open("All_%sBinEdges_%s_%s_%s.tex" %(args.edges, args.model, args.mass, args.channel), "w")
+    h = open("tables/%s/%s_All_%sBinEdges_%s_%s_%s.tex" %(args.channel, args.year, args.edges, args.model, args.mass, args.channel), "w")
     h.write("\\resizebox{\linewidth}{!}{%")
     h.write("\n")
     h.write("\\begin{tabular}{| c | c | c | c | c | c | c |}")
@@ -103,7 +106,7 @@ def main():
     h.write("\n")
 
     # get the nEvents for each ABCD region
-    nEvents_ABCD = open("nEvents_%sABCD_%s_%s_%s.tex" %(args.edges, args.model, args.mass, args.channel), "w")
+    nEvents_ABCD = open("tables/%s/%s_nEvents_%s_ABCD_%s_%s_%s.tex" %(args.channel, args.year, args.edges, args.model, args.mass, args.channel), "w")
     nEvents_ABCD.write("\\resizebox{\linewidth}{!}{%")
     nEvents_ABCD.write("\n")
     nEvents_ABCD.write("\\begin{tabular}{| c | c | c | c | c | c | c |}")
@@ -116,7 +119,7 @@ def main():
     nEvents_ABCD.write("\n")
 
     # get the nEvents for each B'D'EF region 
-    nEvents_bdEF = open("nEvents_%s_Val_bdEF_%s_%s_%s.tex" %(args.edges, args.model, args.mass, args.channel), "w")
+    nEvents_bdEF = open("tables/%s/%s_nEvents_%s_Val_bdEF_%s_%s_%s.tex" %(args.channel, args.year, args.edges, args.model, args.mass, args.channel), "w")
     nEvents_bdEF.write("\\resizebox{\linewidth}{!}{%")
     nEvents_bdEF.write("\n")
     nEvents_bdEF.write("\\begin{tabular}{| c | c | c | c | c | c | c |}")
@@ -129,7 +132,7 @@ def main():
     nEvents_bdEF.write("\n")
 
     # get the nEvents for each C'D'GH region
-    nEvents_cdiGH = open("nEvents_%s_Val_cdiGH_%s_%s_%s.tex" %(args.edges, args.model, args.mass, args.channel), "w")
+    nEvents_cdiGH = open("tables/%s/%s_nEvents_%s_Val_cdiGH_%s_%s_%s.tex" %(args.channel, args.year, args.edges, args.model, args.mass, args.channel), "w")
     nEvents_cdiGH.write("\\resizebox{\linewidth}{!}{%")
     nEvents_cdiGH.write("\n")
     nEvents_cdiGH.write("\\begin{tabular}{| c | c | c | c | c | c | c |}")
@@ -140,6 +143,25 @@ def main():
     nEvents_cdiGH.write("\n")
     nEvents_cdiGH.write("\hline")
     nEvents_cdiGH.write("\n") 
+
+    # get the table for Validation region sub-division D
+    d = open("tables/%s/%s_%s_FinalBinEdges_%s_%s_Val_subDivD_%s_%s.tex" %(args.channel, args.year, args.edges, args.model, args.mass, args.channel, args.metric), "w")
+    d.write("\\resizebox{\linewidth}{!}{%")
+    d.write("\n")
+    d.write("\def\\arraystretch{0.6}")
+    d.write("\n")
+    d.write("\\begin{tabular}{| c | c | c | c | c | c | c | c | c | c | c |}")
+    d.write("\n")
+    d.write("\hline")
+    d.write("\n")
+    d.write("\\textcolor{ttjetscol}{NJets} &  \multicolumn{2}{c|} {\\textcolor{click}{Edges}} & \multicolumn{4}{c|} {\\textcolor{massReg}{SigFracs}} & \multicolumn{4}{c|} {\\textcolor{disc}{nEvents(Sig+Bkg)}} \\\\")
+    d.write("\n")
+    d.write("\hline")
+    d.write("\n")
+    d.write("& \scriptsize \\textcolor{click}{disc1} & \scriptsize \\textcolor{click}{disc2} & \scriptsize \\textcolor{massReg}{sigFrac\_dA} & \scriptsize \\textcolor{massReg}{sigFrac\_dB} & \scriptsize \\textcolor{massReg}{SigFrac\_dC} & \scriptsize \\textcolor{massReg}{SigFrac\_dD} & \scriptsize \\textcolor{disc}{in region dA} & \scriptsize \\textcolor{disc}{in region dB} & \scriptsize \\textcolor{disc}{in region dC} & \scriptsize \\textcolor{disc}{in region dD} \\\\")
+    d.write("\n")
+    d.write("\hline")
+    d.write("\n")
 
     # ---------------
     # loop over njets
@@ -166,7 +188,7 @@ def main():
         binEdges = FinalBinEdges(args.year, args.model, args.mass, args.channel, args.metric, args.edges, njet)
         nTotSigCount_ABCD, nTotBkgCount_ABCD = binEdges.count_Events_inBinEdges(histBkg, histSig)
         finalDisc1Key, finalDisc2Key, significance, closureErr, inverseSignificance, closureErrsList, closureErrUncList, sigUncs, disc1KeyOut, disc2KeyOut, weighted_Sig_A, weighted_Bkg_A, weighted_SigUnc_A, weighted_BkgUnc_A, sigFracsA, sigFracsB, sigFracsC, sigFracsD, sigFracsErrA, sigFracsErrB, sigFracsErrC, sigFracsErrD, sigTotFracsA, sigTotFracsB, sigTotFracsC, sigTotFracsD, bkgTotFracsA, bkgTotFracsB, bkgTotFracsC, bkgTotFracsD, finalSigFracA, finalSigFracB, finalSigFracC, finalSigFracD, nEvents_AB, nEvents_AC, final_nBkgEvents_A, final_nBkgEvents_B, final_nBkgEvents_C, final_nBkgEvents_D = binEdges.get_FinalBinEdges(nTotSigCount_ABCD, nTotBkgCount_ABCD, minBkgFrac = 0.01, minSigFrac = 0.1)   
-      
+        
         # plot variable vs disc as 1D 
         plotter.plot_VarVsDisc(closureErrsList, closureErrUncList, disc1KeyOut, disc2KeyOut, binWidth/2.0, 1.0, "ABCD Closure", "Closure", 1, njet, name = "ABCD")
         plotter.plot_VarVsDisc(closureErrsList, closureErrUncList, disc1KeyOut, disc2KeyOut, binWidth/2.0, 1.0, "ABCD Closure", "Closure", 2, njet, name = "ABCD")
@@ -190,6 +212,8 @@ def main():
         plotter.plot_ClosureError_vsDisc1Disc2(nBins, closureErrsList, closureErrUncList, disc1KeyOut, disc2KeyOut, float(finalDisc1Key), float(finalDisc2Key), minEdge, maxEdge, binWidth, njet, name="ABCD")
         plotter.plot_inverseSignificance_vsClosureErr(significance, closureErr, inverseSignificance, closureErrsList, edges, float(finalDisc1Key), float(finalDisc2Key), njet, name="ABCD")
         plotter.plot_SigFrac_vsDisc1Disc2(nBins, sigFracsA, sigFracsB, sigFracsC, sigFracsD, disc1KeyOut, disc2KeyOut, float(finalDisc1Key), float(finalDisc2Key), minEdge, maxEdge, binWidth, name = "ABCD")
+        plotter.plot_SigTotFrac_vsDisc1Disc2(nBins, sigTotFracsA, sigTotFracsB, sigTotFracsC, sigTotFracsD, disc1KeyOut, disc2KeyOut, float(finalDisc1Key), float(finalDisc2Key), minEdge, maxEdge, binWidth, name="ABCD")
+        plotter.plot_BkgTotFrac_vsDisc1Disc2(nBins, bkgTotFracsA, bkgTotFracsB, bkgTotFracsC, bkgTotFracsD, disc1KeyOut, disc2KeyOut, float(finalDisc1Key), float(finalDisc2Key), minEdge, maxEdge, binWidth, name="ABCD")
 
         # ------------------
         # Validation Regions
@@ -229,9 +253,6 @@ def main():
         #plotter.plot_SigFrac_vsDisc1Disc2(nBins, sigFracsb, sigFracsd, sigFracsE, sigFracsF, disc1KeyOut_bdEF, disc2KeyOut_bdEF, float(finalDisc1Key_bdEF), float(finalDisc2Key_bdEF), minEdge, maxEdge, binWidth, name = "_Val_bdEF")
         #plotter.plot_SigFrac_vsDisc1Disc2(nBins, sigFracsc, sigFracsdi, sigFracsG, sigFracsH, disc1KeyOut_cdiGH, disc2KeyOut_cdiGH, float(finalDisc1Key_cdiGH), float(finalDisc2Key_cdiGH), minEdge, maxEdge, binWidth, name = "_Val_cdiGH")
 
-        # ------------------
-        # make all tex files
-        # ------------------
         # put all latest bin edges to txt file
         h.write("    \\tiny \\textcolor{ttjetscol}{%s}  & \\tiny \\textcolor{click}{%s} & \\tiny \\textcolor{click}{%s} & \\tiny \\textcolor{rpvcol}{%s} & \\tiny \\textcolor{click}{%s} & \\tiny \\textcolor{click}{%s} & \\tiny \\textcolor{disc}{%s} \\\\" %(njet, finalDisc1Key, finalDisc2Key, finalDisc1Key_bdEF, finalDisc2Key_bdEF, finalDisc1Key_cdiGH, finalDisc2Key_cdiGH))
         h.write("\n")
@@ -256,19 +277,38 @@ def main():
         nEvents_cdiGH.write("\hline")
         nEvents_cdiGH.write("\n")
 
-        # ---------------------
-        # plot Disc1s vs Disc2s
-        # ---------------------
+        # -----------------------------------------------------
+        # Validation Regions as SubDivisions of each A, B, C, D
+        # -----------------------------------------------------
+        val_SubDivisionsOfABCD = ValidationRegions_SubDivisionsOfABCD(args.year, args.model, args.mass, args.channel, args.metric, args.edges, njet)
+        nTotSigCount, nTotBkgCount = val_SubDivisionsOfABCD.count_Events_inSubDivisionsOfABCD(histBkg, histSig, float(finalDisc1Key), float(finalDisc2Key))
+        finalDisc1Key_subDivD, finalDisc2Key_subDivD, finalSigFrac_dA, finalSigFrac_dB, finalSigFrac_dC, finalSigFrac_dD, final_nTot_SigBkg_dA, final_nTot_SigBkg_dB, final_nTot_SigBkg_dC, final_nTot_SigBkg_dD = val_SubDivisionsOfABCD.get_ValidationEdges_SubDivisionsOfABCD(nTotSigCount, nTotBkgCount, float(finalDisc1Key), float(finalDisc2Key)) 
+
+        # get the lists to make all closure plots 
+        final_subDivD_Edges.append((finalDisc1Key_subDivD, finalDisc2Key_subDivD))
+        final_nTotBkgCount.append(nTotBkgCount)
+
+        # get the table for Validation region sub-division D
+        d.write("\\tiny \\textcolor{ttjetscol}{%s} &  \\tiny \\textcolor{click}{%s} & \\tiny \\textcolor{click}{%s} & \\tiny \\textcolor{massReg}{%.3f} & \\tiny \\textcolor{massReg}{%.3f} & \\tiny \\textcolor{massReg}{%.3f} & \\tiny \\textcolor{massReg}{%.3f} & \\tiny \\textcolor{disc}{%.2f} & \\tiny \\textcolor{disc}{%.2f} & \\tiny \\textcolor{disc}{%.2f} & \\tiny \\textcolor{disc}{%.2f} \\\\" %(njet, finalDisc1Key_subDivD, finalDisc2Key_subDivD, finalSigFrac_dA, finalSigFrac_dB, finalSigFrac_dC, finalSigFrac_dD, final_nTot_SigBkg_dA, final_nTot_SigBkg_dB, final_nTot_SigBkg_dC, final_nTot_SigBkg_dD) )
+        d.write("\n")
+        d.write("\hline")
+        d.write("\n")
+
+
+        # plot Disc1s vs Disc2s with all edges
         if args.metric == "New":
-            plotter.plot_Disc1VsDisc2(histSig, float(finalDisc1Key), float(finalDisc2Key), float(finalDisc1Key_bdEF), float(finalDisc2Key_cdiGH), tag = "RPV550")
-            plotter.plot_Disc1VsDisc2(histBkg, float(finalDisc1Key), float(finalDisc2Key), float(finalDisc1Key_bdEF), float(finalDisc2Key_cdiGH), tag = "TT")
+            plotter.plot_Disc1VsDisc2(histSig, float(finalDisc1Key), float(finalDisc2Key), float(finalDisc1Key_bdEF), float(finalDisc2Key_cdiGH), tag = "RPV550", name = "Val_BD_CD", col1="yellow", col2="lime")
+            plotter.plot_Disc1VsDisc2(histBkg, float(finalDisc1Key), float(finalDisc2Key), float(finalDisc1Key_bdEF), float(finalDisc2Key_cdiGH), tag = "TT",     name = "Val_BD_CD", col1="yellow", col2="lime")
+            plotter.plot_Disc1VsDisc2(histSig, float(finalDisc1Key), float(finalDisc2Key), float(finalDisc1Key_subDivD), float(finalDisc2Key_subDivD), tag = "RPV550", name = "Val_SubDivD", col1="white", col2="white")
+            plotter.plot_Disc1VsDisc2(histBkg, float(finalDisc1Key), float(finalDisc2Key), float(finalDisc1Key_subDivD), float(finalDisc2Key_subDivD), tag = "TT",     name = "Val_SubDivD", col1="white", col2="white")
 
     # ----------------------
     # make all closure plots
     # ----------------------
-    plotter.make_allClosures(finalBinEdges, final_nTotBkgCount_ABCD, name = "ABCD")
-    plotter.make_allClosures(bdEF_FinalEdges, final_nTotBkgCount_bdEF, name = "Val_bdEF")    
-    plotter.make_allClosures(cdiGH_FinalEdges, final_nTotBkgCount_cdiGH, name = "Val_cdiGH")
+    plotter.make_allClosures(finalBinEdges,       final_nTotBkgCount_ABCD,  name = "ABCD"       )
+    plotter.make_allClosures(bdEF_FinalEdges,     final_nTotBkgCount_bdEF,  name = "Val_bdEF"   )    
+    plotter.make_allClosures(cdiGH_FinalEdges,    final_nTotBkgCount_cdiGH, name = "Val_cdiGH"  )
+    plotter.make_allClosures(final_subDivD_Edges, final_nTotBkgCount,       name = "Val_subDivD")
 
     # ------------------
     # make all tex files
@@ -304,6 +344,15 @@ def main():
     nEvents_cdiGH.write("\n")
     nEvents_cdiGH.write("\n")
     nEvents_cdiGH.close()
+
+    # get the table for Validation region sub-division D
+    d.write("\end{tabular}")
+    d.write("\n")
+    d.write("}")
+    d.write("\n")
+    d.write("\n")
+    d.close()
+
 
 if __name__ == '__main__':
     main()

--- a/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Plotters.py
+++ b/Analyzer/test/DoubleDisCo_BinEdges/DoubleDisCo_BinEdges_Plotters.py
@@ -57,26 +57,12 @@ def main():
     # for 0-lepton 
     if args.channel == "0l":
         histNames = "h_DoubleDisCo_disc1_disc2_0l_Njets"
-        njets = [
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-        ]
+        njets = ["6", "7", "8", "9", "10", "11", "12"]
 
     # for 1-lepton
     else:
         histNames = "h_DoubleDisCo_disc1_disc2_1l_Njets"
-        njets = [
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-        ]
+        njets = ["7", "8", "9", "10", "11"]
 
     # initialize the things
     finalBinEdges       = []; final_nTotBkgCount_ABCD  = [] 


### PR DESCRIPTION
**Validation Regions as Sub-Division of D region:**
1. made dA, dB, dC, dD validations regions with the **_final bin edges_** by requiring:
    – subDivD_disc1 = (final disc1 bin edge / 2) 
    – subDivD_disc2 = (final disc2 bin edge / 2)
2. made dA, dB, dC, dD validations regions with the **_”fixed” final bin edges [(disc1, disc2) = (0.6, 0.6)]_** by requiring:
    – subDivD_disc1 = (0.6 / 2) 
    – subDivD_disc2 = (0.6 / 2)

**We apply:**
1. the **_New optimization metric of the bin edges_**
2. **_RPV_550_** and **_t ̄t_** as signal and background
3. for 0-lepton:
    – used the latest version of the NN outputs applying **_**baseline selection with ≥1top cut**_** 
    – DoubleDisCo_Reg_0l_RPV_2016_v2.0
4. for 1-lepton:
    – used the latest version of the NN outputs applying **_baseline selection_**
    – DoubleDisCo_Reg_1l_RPV_2016_v4.0

**After made them:** 
1. compare the **_signal fractions_** and **_sig+bkg events_**  in each dA, dB, dC, dD validation regions
2. look at closure plots 