### PR TITLE
Update stackPlotter Auxiliary File for TT vs Sig NN Output Comparisons

### DIFF
--- a/Analyzer/test/stackPlotter_aux_ttVsSig_massReg.py
+++ b/Analyzer/test/stackPlotter_aux_ttVsSig_massReg.py
@@ -7,7 +7,9 @@ selections = ["_0l",
 ]
 
 histograms = {
-    "h_DoubleDisCo_massReg?_Njets@"  : {"logY" : False,  "orders" : list(xrange(6,13)), "Y" : {"title" : "A.U.", "min" : 2e-3}, "X" : {"title" : "Regression Mass [GeV]",   "rebin" : 2, "min" : 0,  "max" : 1500}},
+    "h_DoubleDisCo_massReg?_Njets@_ABCD"  : {"logY" : False,  "orders" : list(xrange(7,13)), "Y" : {"title" : "A.U.", "min" : 2e-3}, "X" : {"title" : "Regression Mass [GeV]",   "rebin" : 2, "min" : 0,  "max" : 1500}},
+    "h_DoubleDisCo_disc1?_Njets@"  : {"logY" : False,  "orders" : list(xrange(7,13)), "Y" : {"title" : "A.U.", "min" : 2e-3}, "X" : {"title" : "Neural Network Disc. 1",   "rebin" : 2, "min" : 0,  "max" : 1}},
+    "h_DoubleDisCo_disc2?_Njets@"  : {"logY" : False,  "orders" : list(xrange(7,13)), "Y" : {"title" : "A.U.", "min" : 2e-3}, "X" : {"title" : "Neural Network Disc. 2",   "rebin" : 2, "min" : 0,  "max" : 1}},
 }
 
 backgrounds = {


### PR DESCRIPTION
--for making pretty plots with the `stackPlotter.py` of the two discriminants and mass regression while comparing ttbar with some signals.