### PR TITLE
Small Fix for Configuring MakeMVAVariables

### DIFF
--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -72,11 +72,11 @@ private:
             else if(module=="CommonVariables")                       tr.emplaceModule<CommonVariables>();
             else if(module=="MakeMVAVariables")                      tr.emplaceModule<MakeMVAVariables>(false, "", "GoodJets_pt30",                  false, true, 12, 2, "");
             else if(module=="MakeMVAVariables_NonIsoMuon")           tr.emplaceModule<MakeMVAVariables>(false, "", "NonIsoMuonJets_pt30",            false, true, 12, 2, "");
-            else if(module=="MakeMVAVariables_0l")                   tr.emplaceModule<MakeMVAVariables>(false, "", "GoodJets_pt45",                  false, true, 7,  2, "_0l");
-            else if(module=="MakeMVAVariables_NonIsoMuon_0l")        tr.emplaceModule<MakeMVAVariables>(false, "", "NonIsoMuonJets_pt45",            false, true, 7,  2, "_0l");
+            else if(module=="MakeMVAVariables_0l")                   tr.emplaceModule<MakeMVAVariables>(false, "", "GoodJets_pt30",                  false, true, 7,  2, "_0l");
+            else if(module=="MakeMVAVariables_NonIsoMuon_0l")        tr.emplaceModule<MakeMVAVariables>(false, "", "GoodJets_pt30",                  false, true, 7,  2, "_0l");
             else if(module=="MakeMVAVariables_1l")                   tr.emplaceModule<MakeMVAVariables>(false, "", "GoodJets_pt30",                  false, true, 7,  2, "_1l");
             else if(module=="MakeMVAVariables_NonIsoMuon_1l")        tr.emplaceModule<MakeMVAVariables>(false, "", "NonIsoMuonJets_pt30",            false, true, 7,  2, "_1l");
-            else if(module=="MakeMVAVariables_2l")                   tr.emplaceModule<MakeMVAVariables>(false, "", "GoodJets_pt30_GoodLeptons_pt20", false, true, 12, 2, "_2l");
+            else if(module=="MakeMVAVariables_2l")                   tr.emplaceModule<MakeMVAVariables>(false, "", "GoodJets_pt30_GoodLeptons_pt20", false, true, 7,  2, "_2l");
             else if(module=="Baseline")                              tr.emplaceModule<Baseline>();
             else if(module=="StopGenMatch")                          tr.emplaceModule<StopGenMatch>();
             else if(module=="MegaJetCombine")                        tr.emplaceModule<MegaJetCombine>();
@@ -310,7 +310,42 @@ public:
             };
             registerModules(tr, std::move(modulesList));
         }
-        else if(analyzer=="AnalyzeDoubleDisCo" || analyzer=="MakeNNVariables")
+        else if(analyzer=="AnalyzeDoubleDisCo")
+        {
+            const std::vector<std::string> modulesList = {
+                "PartialUnBlinding",
+                "PrepNTupleVars",
+                "Muon",
+                "Electron",
+                "Photon",
+                "Jet",
+                "BJet",
+                "RunTopTagger",
+                "CommonVariables",
+                "Baseline",
+                "FatJetCombine",
+                "MakeMVAVariables_0l",
+                "MakeMVAVariables_1l",
+                "MakeMVAVariables_NonIsoMuon_0l",
+                "MakeMVAVariables_NonIsoMuon_1l",
+                "StopJets",
+                "MakeStopHemispheres_OldSeed",
+                "MakeStopHemispheres_OldSeed_NonIsoMuon",
+                "BTagCorrector",
+                "ScaleFactors",
+                "StopGenMatch",
+                "DoubleDisCo_0l_RPV",
+                "DoubleDisCo_1l_RPV",
+                "DoubleDisCo_NonIsoMuon_0l_RPV",
+                "DoubleDisCo_NonIsoMuon_1l_RPV",
+                "DoubleDisCo_0l_SYY",
+                "DoubleDisCo_1l_SYY",
+                "DoubleDisCo_NonIsoMuon_0l_SYY",
+                "DoubleDisCo_NonIsoMuon_1l_SYY",
+            };
+            registerModules(tr, std::move(modulesList));
+        }
+        else if(analyzer=="MakeNNVariables")
         {
             const std::vector<std::string> modulesList = {
                 "PartialUnBlinding",
@@ -336,18 +371,10 @@ public:
                 "BTagCorrector",
                 "ScaleFactors",
                 "StopGenMatch",
-                //"DoubleDisCo_0l_RPV",
-                //"DoubleDisCo_1l_RPV",
-                //"DoubleDisCo_NonIsoMuon_0l_RPV",
-                //"DoubleDisCo_NonIsoMuon_1l_RPV",
-                //"DoubleDisCo_0l_SYY",
-                //"DoubleDisCo_1l_SYY",
-                //"DoubleDisCo_NonIsoMuon_0l_SYY",
-                //"DoubleDisCo_NonIsoMuon_1l_SYY",
-                //"DoubleDisCo_2l",
             };
             registerModules(tr, std::move(modulesList));
         }
+
         else if(analyzer=="AnalyzeLepTrigger" || analyzer=="HadTriggers_Analyzer" || analyzer=="CalculateBTagSF" || analyzer=="CalculateSFMean")
         {
             const std::vector<std::string> modulesList = {

--- a/Analyzer/src/AnalyzeDoubleDisCo.cc
+++ b/Analyzer/src/AnalyzeDoubleDisCo.cc
@@ -206,17 +206,13 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool)
     {
         const auto& runtype                           = tr.getVar<std::string>("runtype");     
         const auto& NGoodJets_pt30                    = tr.getVar<int>("NGoodJets_pt30");
-        const auto& NGoodJets_pt45                    = tr.getVar<int>("NGoodJets_pt45");
         const auto& NNonIsoMuonJets_pt30              = tr.getVar<int>("NNonIsoMuonJets_pt30");
-        const auto& NNonIsoMuonJets_pt45              = tr.getVar<int>("NNonIsoMuonJets_pt45");
         const auto& HT_trigger_pt30                   = tr.getVar<double>("HT_trigger_pt30");
-        const auto& HT_trigger_pt45                   = tr.getVar<double>("HT_trigger_pt45");
         const auto& HT_NonIsoMuon_pt30                = tr.getVar<double>("HT_NonIsoMuon_pt30");
-        const auto& HT_NonIsoMuon_pt45                = tr.getVar<double>("HT_NonIsoMuon_pt45");
 
-        const auto& passBaseline0l_Good               = tr.getVar<bool>("passBaseline0l_Good");
+        const auto& passBaseline0l_Good               = tr.getVar<bool>("passBaseline0l_good");
         const auto& passBaseline1l_Good               = tr.getVar<bool>("passBaseline1l_Good");
-        const auto& passBaseline0l_NonIsoMuon         = tr.getVar<bool>("passBaseline0l_NonIsoMuon");
+        const auto& passBaseline0l_NonIsoMuon         = tr.getVar<bool>("pass_qcdCR");
         const auto& passBaseline1l_NonIsoMuon         = tr.getVar<bool>("passBaseline1l_NonIsoMuon");
 
         const auto& DoubleDisCo_massReg_0l            = tr.getVar<double>("DoubleDisCo_massReg_0l_RPV");
@@ -246,13 +242,13 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool)
         const auto& jmt_ev0_top6_1l                   = tr.getVar<double>("jmt_ev0_top6_1l");
         const auto& jmt_ev1_top6_1l                   = tr.getVar<double>("jmt_ev1_top6_1l");
         const auto& jmt_ev2_top6_1l                   = tr.getVar<double>("jmt_ev2_top6_1l");
-        const auto& NonIsoMuons_fwm2_top6_0l          = tr.getVar<double>("NonIsoMuons_fwm2_top6_0l");
-        const auto& NonIsoMuons_fwm3_top6_0l          = tr.getVar<double>("NonIsoMuons_fwm3_top6_0l");
-        const auto& NonIsoMuons_fwm4_top6_0l          = tr.getVar<double>("NonIsoMuons_fwm4_top6_0l");
-        const auto& NonIsoMuons_fwm5_top6_0l          = tr.getVar<double>("NonIsoMuons_fwm5_top6_0l");
-        const auto& NonIsoMuons_jmt_ev0_top6_0l       = tr.getVar<double>("NonIsoMuons_jmt_ev0_top6_0l");
-        const auto& NonIsoMuons_jmt_ev1_top6_0l       = tr.getVar<double>("NonIsoMuons_jmt_ev1_top6_0l");
-        const auto& NonIsoMuons_jmt_ev2_top6_0l       = tr.getVar<double>("NonIsoMuons_jmt_ev2_top6_0l");
+        const auto& NonIsoMuons_fwm2_top6_0l          = tr.getVar<double>("fwm2_top6_0l");
+        const auto& NonIsoMuons_fwm3_top6_0l          = tr.getVar<double>("fwm3_top6_0l");
+        const auto& NonIsoMuons_fwm4_top6_0l          = tr.getVar<double>("fwm4_top6_0l");
+        const auto& NonIsoMuons_fwm5_top6_0l          = tr.getVar<double>("fwm5_top6_0l");
+        const auto& NonIsoMuons_jmt_ev0_top6_0l       = tr.getVar<double>("jmt_ev0_top6_0l");
+        const auto& NonIsoMuons_jmt_ev1_top6_0l       = tr.getVar<double>("jmt_ev1_top6_0l");
+        const auto& NonIsoMuons_jmt_ev2_top6_0l       = tr.getVar<double>("jmt_ev2_top6_0l");
         const auto& NonIsoMuons_fwm2_top6_1l          = tr.getVar<double>("NonIsoMuons_fwm2_top6_1l");
         const auto& NonIsoMuons_fwm3_top6_1l          = tr.getVar<double>("NonIsoMuons_fwm3_top6_1l");
         const auto& NonIsoMuons_fwm4_top6_1l          = tr.getVar<double>("NonIsoMuons_fwm4_top6_1l");
@@ -263,7 +259,7 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool)
 
         const auto& Jets_cm_top6_0l                   = tr.getVec<TLorentzVector>("Jets_cm_top6_0l");
         const auto& Jets_cm_top6_1l                   = tr.getVec<TLorentzVector>("Jets_cm_top6_1l");
-        const auto& NonIsoMuons_Jets_cm_top6_0l       = tr.getVec<TLorentzVector>("NonIsoMuons_Jets_cm_top6_0l");
+        const auto& NonIsoMuons_Jets_cm_top6_0l       = tr.getVec<TLorentzVector>("Jets_cm_top6_0l");
         const auto& NonIsoMuons_Jets_cm_top6_1l       = tr.getVec<TLorentzVector>("NonIsoMuons_Jets_cm_top6_1l");
         const auto& nMVAJets_0l                       = tr.getVar<unsigned int>("nMVAJets_0l");
         const auto& nMVAJets_1l                       = tr.getVar<unsigned int>("nMVAJets_1l");
@@ -323,11 +319,11 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool)
             Jets_flavuds_0l.push_back(tr.getVar<double>("Jet_flavuds_"+std::to_string(iJet)+"_0l"));
             Jets_flavq_0l.push_back(tr.getVar<double>("Jet_flavq_"+std::to_string(iJet)+"_0l"));
 
-            JetNonIsoMuons_flavb_0l.push_back(tr.getVar<double>("JetNonIsoMuons_flavb_"+std::to_string(iJet)+"_0l"));
-            JetNonIsoMuons_flavc_0l.push_back(tr.getVar<double>("JetNonIsoMuons_flavc_"+std::to_string(iJet)+"_0l"));
-            JetNonIsoMuons_flavg_0l.push_back(tr.getVar<double>("JetNonIsoMuons_flavg_"+std::to_string(iJet)+"_0l"));
-            JetNonIsoMuons_flavuds_0l.push_back(tr.getVar<double>("JetNonIsoMuons_flavuds_"+std::to_string(iJet)+"_0l"));
-            JetNonIsoMuons_flavq_0l.push_back(tr.getVar<double>("JetNonIsoMuons_flavq_"+std::to_string(iJet)+"_0l"));
+            JetNonIsoMuons_flavb_0l.push_back(tr.getVar<double>("Jet_flavb_"+std::to_string(iJet)+"_0l"));
+            JetNonIsoMuons_flavc_0l.push_back(tr.getVar<double>("Jet_flavc_"+std::to_string(iJet)+"_0l"));
+            JetNonIsoMuons_flavg_0l.push_back(tr.getVar<double>("Jet_flavg_"+std::to_string(iJet)+"_0l"));
+            JetNonIsoMuons_flavuds_0l.push_back(tr.getVar<double>("Jet_flavuds_"+std::to_string(iJet)+"_0l"));
+            JetNonIsoMuons_flavq_0l.push_back(tr.getVar<double>("Jet_flavq_"+std::to_string(iJet)+"_0l"));
         }
 
         for (unsigned int iJet = 1; iJet <= nMVAJets_1l; iJet++) {
@@ -346,10 +342,10 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool)
 
         // Put 0L and 1L version of variables into vector
         // 0th position is for 0L and 1st position is for 1L for convenience in the event loop
-        std::vector<int>                                        NGoodJets                     {NGoodJets_pt45,                        NGoodJets_pt30};
-        std::vector<int>                                        NNonIsoMuonJets               {NNonIsoMuonJets_pt45,                  NNonIsoMuonJets_pt30};
-        std::vector<double>                                     HT_trigger                    {HT_trigger_pt45,                       HT_trigger_pt30};
-        std::vector<double>                                     HT_NonIsoMuon                 {HT_NonIsoMuon_pt45,                    HT_NonIsoMuon_pt30};
+        std::vector<int>                                        NGoodJets                     {NGoodJets_pt30,                        NGoodJets_pt30};
+        std::vector<int>                                        NNonIsoMuonJets               {NNonIsoMuonJets_pt30,                  NNonIsoMuonJets_pt30};
+        std::vector<double>                                     HT_trigger                    {HT_trigger_pt30,                       HT_trigger_pt30};
+        std::vector<double>                                     HT_NonIsoMuon                 {HT_NonIsoMuon_pt30,                    HT_NonIsoMuon_pt30};
         std::vector<double>                                     DoubleDisCo_massReg           {DoubleDisCo_massReg_0l,                DoubleDisCo_massReg_1l};
         std::vector<double>                                     DoubleDisCo_disc1             {DoubleDisCo_disc1_0l,                  DoubleDisCo_disc1_1l};
         std::vector<double>                                     DoubleDisCo_disc2             {DoubleDisCo_disc2_0l,                  DoubleDisCo_disc2_1l};
@@ -428,7 +424,6 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool)
         }
 
         std::vector<double> weight        {weight0L,            weight1L};
-        std::vector<double> weight_noHTsf {weight0L_noHTsf,     weight1L_noHTsf};
         std::vector<double> weight_QCDCR  {weight0L_NonIsoMuon, weight1L_NonIsoMuon};
 
         const std::map<std::string, bool> cut_map 
@@ -437,7 +432,6 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool)
             {"_0l"            , passBaseline0l_Good},                         
             {"_1l_QCDCR"      , passBaseline1l_NonIsoMuon},                         
             {"_0l_QCDCR"      , passBaseline0l_NonIsoMuon},                         
-            {"_1l_noHTsf"     , passBaseline1l_Good},                         
         };
 
         std::map<std::string, bool>               njetsMap;
@@ -462,7 +456,6 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool)
                 channel = std::stoi(kv.first.substr(1,1));
 
             bool isQCD  = kv.first.find("QCDCR")  != std::string::npos;
-            bool noHTsf = kv.first.find("noHTsf") != std::string::npos;
 
             njetsMap = {{"Incl",     true},
                         {"7",      !isQCD ? NGoodJets[channel]==7  : NNonIsoMuonJets[channel]==7},
@@ -480,10 +473,7 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool)
                 ABCDmap[region] = !isQCD ? DoubleDisCo_passRegions[channel][region] : DoubleDisCo_passRegions_QCDCR[channel][region];
 
             double w = 1.0;
-            if (noHTsf)
-                w = !isQCD ? weight_noHTsf[channel] : weight_QCDCR[channel];
-            else
-                w = !isQCD ? weight[channel]        : weight_QCDCR[channel];
+            w = !isQCD ? weight[channel]        : weight_QCDCR[channel];
 
             std::string name;
             for (auto& njetsPass : njetsMap)

--- a/Analyzer/test/stackPlotter.py
+++ b/Analyzer/test/stackPlotter.py
@@ -672,6 +672,7 @@ if __name__ == "__main__":
     parser.add_argument("--normMC2Data",  dest="normMC2Data",  help="Normalize MC to data",        default=False,  action="store_true") 
     parser.add_argument("--normalize",    dest="normalize",    help="Normalize all to unity",      default=False,  action="store_true") 
     parser.add_argument("--printInfo",    dest="printInfo",    help="Print significance and cuts", default=False,  action="store_true")
+    parser.add_argument("--makeTable",    dest="makeTable",    help="Make the table of fracs",     default=False,  action="store_true")
     parser.add_argument("--inpath",       dest="inpath",       help="Path to root files",          default="NULL", required=True)
     parser.add_argument("--outpath",      dest="outpath",      help="Where to put plots",          default="NULL", required=True)
     parser.add_argument("--year",         dest="year",         help="which year",                                  required=True)
@@ -696,3 +697,6 @@ if __name__ == "__main__":
     plotter = StackPlotter(args.approved, args.noRatio, args.printNEvents, args.printInfo, args.year, args.outpath, args.inpath, args.normMC2Data, args.normalize, histograms, selections, backgrounds, signals, data)
     plotter.makePlots()
     plotter.make_njetsTable()
+
+    if args.makeTable:
+        plotter.makeTable()

--- a/Analyzer/test/stackPlotter_aux.py
+++ b/Analyzer/test/stackPlotter_aux.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 
 selections = [
         #"_0l",
-        #"_1l",
+        "_1l",
         #"_1l_QCDCR",
         
         # >= 6 jets
@@ -136,8 +136,8 @@ histograms = {
     #"Stop@_phi_cm_OldSeed?"         : {"logY" : False, "orders" : list(xrange(1,3)),  "Y" : {"title" : "Weighted Events", "min" : 0.2},  "X" : {"title" : "Stop @ #phi",           "rebin" : 1, "min" : -6, "max" :    6}},
     #"h_njets?"                      : {"logY" : True,                                 "Y" : {"title" : "Weighted Events", "min" : 2e-3}, "X" : {"title" : "N_{jets}",              "rebin" : 1, "min" :  6, "max" :   18}},
     #"h_DoubleDisCo_massReg?_Njets@" : {"logY" : False, "orders" : list(xrange(7,13)), "Y" : {"title" : "A.U.",            "min" : 2e-3}, "X" : {"title" : "Regression Mass [GeV]", "rebin" : 2, "min" :  0, "max" : 1500}},
-    #"h_njets_?"                      : {"logY" : True,                                 "Y" : {"title" : "Events",         "min" : 2e-3}, "X" : {"title" : "N_{jets}", "rebin" : 1, "min" :  -0.5, "max" : 20.5}},
     "h_ntops_?"                      : {"logY" : True,                                 "Y" : {"title" : "Events",         "min" : 2e-3}, "X" : {"title" : "N_{tops}", "rebin" : 1, "min" :  -0.5, "max" : 10.5}},
+    "h_njets?"                      : {"logY" : True,                                 "Y" : {"title" : "Events",         "min" : 2e-3}, "X" : {"title" : "N_{jets}", "rebin" : 1, "min" :  -0.5, "max" : 20.5}},
 }
 
 backgrounds = {

--- a/Analyzer/test/stackPlotter_aux_ttVsSig_massReg.py
+++ b/Analyzer/test/stackPlotter_aux_ttVsSig_massReg.py
@@ -7,9 +7,13 @@ selections = ["_0l",
 ]
 
 histograms = {
-    "h_DoubleDisCo_massReg?_Njets@_ABCD"  : {"logY" : False,  "orders" : list(xrange(7,13)), "Y" : {"title" : "A.U.", "min" : 2e-3}, "X" : {"title" : "Regression Mass [GeV]",   "rebin" : 2, "min" : 0,  "max" : 1500}},
-    "h_DoubleDisCo_disc1?_Njets@"  : {"logY" : False,  "orders" : list(xrange(7,13)), "Y" : {"title" : "A.U.", "min" : 2e-3}, "X" : {"title" : "Neural Network Disc. 1",   "rebin" : 2, "min" : 0,  "max" : 1}},
-    "h_DoubleDisCo_disc2?_Njets@"  : {"logY" : False,  "orders" : list(xrange(7,13)), "Y" : {"title" : "A.U.", "min" : 2e-3}, "X" : {"title" : "Neural Network Disc. 2",   "rebin" : 2, "min" : 0,  "max" : 1}},
+    "h_DoubleDisCo_massReg?_Njets@_ABCD"  : {"logY" : True,  "orders" : list(xrange(7,12)), "Y" : {"title" : "A.U.", "min" : 2e-3}, "X" : {"title" : "Regression Mass [GeV]",   "rebin" : 2, "min" : 0,  "max" : 1500}},
+    "h_DoubleDisCo_massReg?_Njets11incl_ABCD"  : {"logY" : True, "Y" : {"title" : "A.U.", "min" : 2e-3}, "X" : {"title" : "Regression Mass [GeV]",   "rebin" : 2, "min" : 0,  "max" : 1500}},
+    "h_DoubleDisCo_disc1?_Njets@"  : {"logY" : False,  "orders" : list(xrange(7,12)), "Y" : {"title" : "A.U.", "min" : 2e-3}, "X" : {"title" : "Neural Network Disc. 1",   "rebin" : 2, "min" : 0,  "max" : 1}},
+    "h_DoubleDisCo_disc2?_Njets@"  : {"logY" : False,  "orders" : list(xrange(7,12)), "Y" : {"title" : "A.U.", "min" : 2e-3}, "X" : {"title" : "Neural Network Disc. 2",   "rebin" : 2, "min" : 0,  "max" : 1}},
+    "h_DoubleDisCo_disc1?_Njets11incl"  : {"logY" : False,  "Y" : {"title" : "A.U.", "min" : 2e-3}, "X" : {"title" : "Neural Network Disc. 1",   "rebin" : 2, "min" : 0,  "max" : 1}},
+    "h_DoubleDisCo_disc2?_Njets11incl"  : {"logY" : False,  "Y" : {"title" : "A.U.", "min" : 2e-3}, "X" : {"title" : "Neural Network Disc. 2",   "rebin" : 2, "min" : 0,  "max" : 1}},
+
 }
 
 backgrounds = {


### PR DESCRIPTION
--in `Config.h`, use pt30 jets for 0L configuration of `MakeMVAVariables`
--separate list of modules between `AnalyzeDoubleDisCo` and `MakeNNVariables`
--update `AnalyzeDoubleDisCo` to use latest updates for 0L
--add `makeTable` option to `stackPlotter.py` to allow toggling on/off
--update aux for plotting NN outputs