### PR TITLE
Use RPV NN Configs for SYY at the Moment

### DIFF
--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -154,12 +154,14 @@ public:
             DoubleDisCo_Cfg_1l_RPV            = "Keras_Tensorflow_DoubleDisCo_Reg_1l_RPV_2016.cfg";
             DoubleDisCo_Model_1l_RPV          = "keras_frozen_DoubleDisCo_Reg_1l_RPV_2016.pb";
             DoubleDisCo_Cfg_NonIsoMuon_1l_RPV = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_1l_RPV_2016.cfg";
-            DoubleDisCo_Cfg_0l_SYY            = "Keras_Tensorflow_DoubleDisCo_Reg_0l_SYY_2016.cfg";           
-            DoubleDisCo_Model_0l_SYY          = "keras_frozen_DoubleDisCo_Reg_0l_SYY_2016.pb";
-            DoubleDisCo_Cfg_NonIsoMuon_0l_SYY = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_0l_SYY_2016.cfg";
-            DoubleDisCo_Cfg_1l_SYY            = "Keras_Tensorflow_DoubleDisCo_Reg_1l_SYY_2016.cfg";
-            DoubleDisCo_Model_1l_SYY          = "keras_frozen_DoubleDisCo_Reg_1l_SYY_2016.pb";
-            DoubleDisCo_Cfg_NonIsoMuon_1l_SYY = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_1l_SYY_2016.cfg";
+
+            // Use RPV config for now --- switch to SYY with dedicated training
+            DoubleDisCo_Cfg_0l_SYY            = "Keras_Tensorflow_DoubleDisCo_Reg_0l_RPV_2016.cfg";           
+            DoubleDisCo_Model_0l_SYY          = "keras_frozen_DoubleDisCo_Reg_0l_RPV_2016.pb";
+            DoubleDisCo_Cfg_NonIsoMuon_0l_SYY = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_0l_RPV_2016.cfg";
+            DoubleDisCo_Cfg_1l_SYY            = "Keras_Tensorflow_DoubleDisCo_Reg_1l_RPV_2016.cfg";
+            DoubleDisCo_Model_1l_SYY          = "keras_frozen_DoubleDisCo_Reg_1l_RPV_2016.pb";
+            DoubleDisCo_Cfg_NonIsoMuon_1l_SYY = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_1l_RPV_2016.cfg";
 
             //DoubleDisCo_Cfg_2l    = "Keras_Tensorflow_DoubleDisCo_Reg_2l_2016.cfg";
             //DoubleDisCo_Model_2l  = "keras_frozen_DoubleDisCo_Reg_2l_2016.pb";
@@ -292,7 +294,6 @@ public:
         if(analyzer=="MakeNJetDists") // for legacy 1l
         {
             const std::vector<std::string> modulesList = {
-                "PartialUnBlinding",
                 "PrepNTupleVars",
                 "Muon",
                 "Electron",
@@ -313,7 +314,6 @@ public:
         else if(analyzer=="AnalyzeDoubleDisCo")
         {
             const std::vector<std::string> modulesList = {
-                "PartialUnBlinding",
                 "PrepNTupleVars",
                 "Muon",
                 "Electron",
@@ -348,7 +348,6 @@ public:
         else if(analyzer=="MakeNNVariables")
         {
             const std::vector<std::string> modulesList = {
-                "PartialUnBlinding",
                 "PrepNTupleVars",
                 "Muon",
                 "Electron",
@@ -378,7 +377,6 @@ public:
         else if(analyzer=="AnalyzeLepTrigger" || analyzer=="HadTriggers_Analyzer" || analyzer=="CalculateBTagSF" || analyzer=="CalculateSFMean")
         {
             const std::vector<std::string> modulesList = {
-                "PartialUnBlinding",
                 "PrepNTupleVars",
                 "Muon",
                 "Electron",
@@ -395,7 +393,6 @@ public:
         else if(analyzer=="Semra_Analyzer" || analyzer=="AnalyzeTopTagger")
         {   
             const std::vector<std::string> modulesList = {
-                "PartialUnBlinding",
                 "PrepNTupleVars",
                 "Muon",
                 "Electron",
@@ -428,7 +425,6 @@ public:
         else if(analyzer=="StealthHemispheres" || analyzer=="ISRJets_Analyzer")
         {
             const std::vector<std::string> modulesList = {
-                "PartialUnBlinding",
                 "PrepNTupleVars",
                 "Muon",
                 "Electron",
@@ -457,7 +453,6 @@ public:
         else if(analyzer=="Analyze1Lep")
         {
             const std::vector<std::string> modulesList = {
-                "PartialUnBlinding",
                 "PrepNTupleVars",
                 "Muon",
                 "Electron",
@@ -480,7 +475,6 @@ public:
         else if(analyzer=="TwoLepAnalyzer" || analyzer=="Make2LInputTrees")
         {   
             const std::vector<std::string> modulesList = {
-                "PartialUnBlinding",
                 "PrepNTupleVars",
                 "Muon",
                 "Electron",
@@ -501,7 +495,6 @@ public:
         else
         {
             const std::vector<std::string> modulesList = {
-                "PartialUnBlinding",
                 "PrepNTupleVars",
                 "Muon",
                 "Electron",


### PR DESCRIPTION
--point the code to the RPV-dedicated training files for use with SYY, to be reverted back when SYY-dedicated training files are available.
--remove `PartialUnblinding` module from analyzer paths, deprecated at the moment.