### PR TITLE
2018 UL HEM study for both 0l and 1l

### DIFF
--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -449,7 +449,6 @@ public:
             };
             registerModules(tr, std::move(modulesList));
         }
-
         else if(analyzer=="AnalyzeLepTrigger" || analyzer=="HadTriggers_Analyzer" || analyzer=="CalculateBTagSF" || analyzer=="CalculateSFMean")
         {
             const std::vector<std::string> modulesList = {
@@ -467,6 +466,28 @@ public:
             };
             registerModules(tr, std::move(modulesList));
         }
+        else if(analyzer=="HEM_Analyzer" || analyzer=="AnalyzeHEM")
+        {
+            const std::vector<std::string> modulesList = {
+                "PrepNTupleVars",
+                "Muon",
+                "Electron",
+                "Photon",
+                "Jet",
+                "BJet",
+                "RunTopTagger",
+                "CommonVariables",
+                "FatJetCombine",
+                "Baseline",
+                //"BTagCorrector",
+                //"ScaleFactors",        
+                "MakeMVAVariables",
+                //"StopJets",
+                //"MakeStopHemispheres_OldSeed",
+                //"MakeStopHemispheres_TopSeed",
+            };
+            registerModules(tr, std::move(modulesList));
+        }       
         else if(analyzer=="Semra_Analyzer" || analyzer=="WholeTopTagger_Analyzer" || analyzer=="ResolvedTopTagger_Analyzer")
         {   
             const std::vector<std::string> modulesList = {

--- a/Analyzer/include/HEM_Analyzer.h
+++ b/Analyzer/include/HEM_Analyzer.h
@@ -1,0 +1,29 @@
+#ifndef HEM_Analyzer_h
+#define HEM_Analyzer_h
+
+#include <TH1D.h>
+#include <TH2D.h>
+#include <TTree.h>
+
+#include <map>
+#include <string>
+
+class NTupleReader;
+
+class HEM_Analyzer 
+{
+public:
+    std::map<std::string, std::shared_ptr<TH1D>>  my_histos;
+    std::map<std::string, std::shared_ptr<TH2D>>  my_2d_histos;
+    bool inithisto;   
+ 
+    HEM_Analyzer();
+    ~HEM_Analyzer(){};
+    
+    void Loop(NTupleReader& tr, double weight, int maxevents = -1, bool isQuiet = false);
+    void InitHistos(const std::map<std::string, bool>& cutmap);
+    void WriteHistos(TFile* outfile);   
+    
+};
+
+#endif

--- a/Analyzer/src/AnalyzeHEM.cc
+++ b/Analyzer/src/AnalyzeHEM.cc
@@ -110,10 +110,10 @@ void AnalyzeHEM::Loop(NTupleReader& tr, double, int maxevents, bool)
         const auto& NGoodJets_pt30      = tr.getVar<int>("NGoodJets_pt30");
         const auto& RunNum              = tr.getVar<unsigned int>("RunNum");
         const auto& met                 = tr.getVar<float>("MET");
-        const auto& lvMET_cm_pt         = tr.getVar<float>("lvMET_cm_pt");
-        const auto& lvMET_cm_eta        = tr.getVar<float>("lvMET_cm_eta");
-        const auto& lvMET_cm_phi        = tr.getVar<float>("lvMET_cm_phi");
-        const auto& lvMET_cm_m          = tr.getVar<float>("lvMET_cm_m");
+        const auto& lvMET_cm_pt         = tr.getVar<double>("lvMET_cm_pt");
+        const auto& lvMET_cm_eta        = tr.getVar<double>("lvMET_cm_eta");
+        const auto& lvMET_cm_phi        = tr.getVar<double>("lvMET_cm_phi");
+        const auto& lvMET_cm_m          = tr.getVar<double>("lvMET_cm_m");
         const auto& fwm2_top6           = tr.getVar<double>("fwm2_top6");
         const auto& fwm3_top6           = tr.getVar<double>("fwm3_top6");
         const auto& fwm4_top6           = tr.getVar<double>("fwm4_top6");
@@ -126,9 +126,10 @@ void AnalyzeHEM::Loop(NTupleReader& tr, double, int maxevents, bool)
         const auto& jmt_ev0_top6        = tr.getVar<double>("jmt_ev0_top6");
         const auto& jmt_ev1_top6        = tr.getVar<double>("jmt_ev1_top6");
         const auto& jmt_ev2_top6        = tr.getVar<double>("jmt_ev2_top6");
-        const auto& event_beta_z        = tr.getVar<float>("event_beta_z");
+        const auto& event_beta_z        = tr.getVar<double>("event_beta_z");
         const auto& passMadHT           = tr.getVar<bool>("passMadHT");
-        const auto& passBaseline        = tr.getVar<bool>("passBaseline1l_Good");
+        const auto& passBaseline_1l     = tr.getVar<bool>("passBaseline1l_Good");
+        const auto& passBaseline_0l     = tr.getVar<bool>("passBaseline0l_good");
      
         if(maxevents != -1 && tr.getEvtNum() >= maxevents) break;        
         if ( tr.getEvtNum() % 1000 == 0 ) printf("  Event %i\n", tr.getEvtNum() ) ;
@@ -148,29 +149,30 @@ void AnalyzeHEM::Loop(NTupleReader& tr, double, int maxevents, bool)
         {
             if( !passMadHT ) continue; //Make sure not to double count DY events
             // Define Lumi weight
-            const auto& Weight  = tr.getVar<float>("Weight");
-            const auto& lumi = tr.getVar<double>("Lumi");
-            eventweight = lumi*Weight;
+            const auto& Weight = tr.getVar<float>("Weight");
+            const auto& lumi   = tr.getVar<double>("Lumi");
+            eventweight        = lumi*Weight;
             
             // Define lepton weight
-            if(NGoodLeptons == 1)
-            {
-                const auto& eleLepWeight = tr.getVar<double>("totGoodElectronSF");
-                const auto& muLepWeight  = tr.getVar<double>("totGoodMuonSF");
-                leptonScaleFactor = (GoodLeptons[0].first == "e") ? eleLepWeight : muLepWeight;
-            }
+            //if(NGoodLeptons == 1)
+            //{
+            //    const auto& eleLepWeight = tr.getVar<double>("totGoodElectronSF");
+            //    const auto& muLepWeight  = tr.getVar<double>("totGoodMuonSF");
+            //    leptonScaleFactor        = (GoodLeptons[0].first == "e") ? eleLepWeight : muLepWeight;
+            //}
             
-            //PileupWeight = tr.getVar<float>("_PUweightFactor");
-            bTagScaleFactor   = tr.getVar<double>("bTagSF_EventWeightSimple_Central");
-            htDerivedScaleFactor = tr.getVar<double>("htDerivedweight");
-            prefiringScaleFactor = tr.getVar<double>("prefiringScaleFactor");
-            puScaleFactor = tr.getVar<double>("puWeightCorr");
+            //PileupWeight         = tr.getVar<float>("_PUweightFactor");
+            //bTagScaleFactor      = tr.getVar<double>("bTagSF_EventWeightSimple_Central");
+            //htDerivedScaleFactor = tr.getVar<double>("htDerivedweight");
+            //prefiringScaleFactor = tr.getVar<double>("prefiringScaleFactor");
+            //puScaleFactor        = tr.getVar<double>("puWeightCorr");
             
-            weight *= eventweight*leptonScaleFactor*bTagScaleFactor*htDerivedScaleFactor*prefiringScaleFactor*puScaleFactor;
+            //weight *= eventweight*leptonScaleFactor*bTagScaleFactor*htDerivedScaleFactor*prefiringScaleFactor*puScaleFactor;
+            weight *= eventweight;
         }
 
         //Make cuts and fill histograms here
-        if( passBaseline ) {
+        if( passBaseline_1l ) {
 
             double jetPtMax = 0.0;
             if ( RunNum < 319077 ) {

--- a/Analyzer/src/HEM_Analyzer.cc
+++ b/Analyzer/src/HEM_Analyzer.cc
@@ -1,0 +1,338 @@
+#define HEM_Analyzer_cxx
+#include "Analyzer/Analyzer/include/HEM_Analyzer.h"
+#include "Framework/Framework/include/Utility.h"
+#include "NTupleReader/include/NTupleReader.h"
+
+#include <TH1D.h>
+#include <TH2D.h>
+#include <TStyle.h>
+#include <TCanvas.h>
+#include <TEfficiency.h>
+#include <TRandom3.h>
+#include <iostream>
+#include <TFile.h>
+#include <TDirectory.h>
+#include <TH1F.h>
+
+HEM_Analyzer::HEM_Analyzer() : inithisto(false) // define inithisto variable
+{
+}
+
+// -------------------
+// -- Define histos
+// -------------------
+void HEM_Analyzer::InitHistos(const std::map<std::string, bool>& cutmap) // define variable map
+{
+    TH1::SetDefaultSumw2();
+    TH2::SetDefaultSumw2();
+    
+    my_histos.emplace( "EventCounter", std::make_shared<TH1D>( "EventCounter", "EventCounter", 2, -1.1, 1.1 ) ) ;
+    
+    for (const auto& cutVar : cutmap) 
+    {
+        // ----------------
+        // before HEM issue
+        // ----------------
+        // 1D histograms
+        my_histos.emplace( "h_njets_"        +cutVar.first, std::make_shared<TH1D> ( ("h_njets_"        +cutVar.first).c_str(), ("h_njets_"        +cutVar.first).c_str(), 13, 6.5, 19.5     ) );
+        my_histos.emplace( "h_nbjets_"       +cutVar.first, std::make_shared<TH1D> ( ("h_nbjets_"       +cutVar.first).c_str(), ("h_nbjets_"       +cutVar.first).c_str(), 15, -0.5, 14.5    ) );
+        my_histos.emplace( "h_met_"          +cutVar.first, std::make_shared<TH1D> ( ("h_met_"          +cutVar.first).c_str(), ("h_met_"          +cutVar.first).c_str(), 720, 0, 1500      ) );
+        my_histos.emplace( "h_ht_"           +cutVar.first, std::make_shared<TH1D> ( ("h_ht_"           +cutVar.first).c_str(), ("h_ht_"           +cutVar.first).c_str(), 720, 300, 5000    ) );
+        my_histos.emplace( "h_jetPt_"        +cutVar.first, std::make_shared<TH1D> ( ("h_jetPt_"        +cutVar.first).c_str(), ("h_jetPt_"        +cutVar.first).c_str(), 1440, 0, 5000     ) );
+        my_histos.emplace( "h_jetPtMax_"     +cutVar.first, std::make_shared<TH1D> ( ("h_jetPtMax_"     +cutVar.first).c_str(), ("h_jetPtMax_"     +cutVar.first).c_str(), 1440, 0, 5000     ) );
+        my_histos.emplace( "h_lvMET_cm_mass_"+cutVar.first, std::make_shared<TH1D> ( ("h_lvMET_cm_mass_"+cutVar.first).c_str(), ("h_lvMET_cm_mass_"+cutVar.first).c_str(), 1440, 0, 1000     ) );
+        my_histos.emplace( "h_lvMET_cm_eta_" +cutVar.first, std::make_shared<TH1D> ( ("h_lvMET_cm_eta_" +cutVar.first).c_str(), ("h_lvMET_cm_eta_" +cutVar.first).c_str(), 1440, -2.5, 2.5   ) );
+        my_histos.emplace( "h_lvMET_cm_phi_" +cutVar.first, std::make_shared<TH1D> ( ("h_lvMET_cm_phi_" +cutVar.first).c_str(), ("h_lvMET_cm_phi_" +cutVar.first).c_str(), 1440, -3.14, 3.14 ) );
+        my_histos.emplace( "h_lvMET_cm_pt_"  +cutVar.first, std::make_shared<TH1D> ( ("h_lvMET_cm_pt_"  +cutVar.first).c_str(), ("h_lvMET_cm_pt_"  +cutVar.first).c_str(), 1440, 0, 1000     ) );
+        my_histos.emplace( "h_fwm2_top6_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm2_top6_"    +cutVar.first).c_str(), ("h_fwm2_top6_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm3_top6_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm3_top6_"    +cutVar.first).c_str(), ("h_fwm3_top6_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm4_top6_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm4_top6_"    +cutVar.first).c_str(), ("h_fwm4_top6_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm5_top6_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm5_top6_"    +cutVar.first).c_str(), ("h_fwm5_top6_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm6_top6_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm6_top6_"    +cutVar.first).c_str(), ("h_fwm6_top6_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm7_top6_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm7_top6_"    +cutVar.first).c_str(), ("h_fwm7_top6_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm8_top6_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm8_top6_"    +cutVar.first).c_str(), ("h_fwm8_top6_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm9_top6_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm9_top6_"    +cutVar.first).c_str(), ("h_fwm9_top6_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm10_top6_"   +cutVar.first, std::make_shared<TH1D> ( ("h_fwm10_top6_"   +cutVar.first).c_str(), ("h_fwm10_top6_"   +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_jmt_ev0_top6_" +cutVar.first, std::make_shared<TH1D> ( ("h_jmt_ev0_top6_" +cutVar.first).c_str(), ("h_jmt_ev0_top6_" +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_jmt_ev1_top6_" +cutVar.first, std::make_shared<TH1D> ( ("h_jmt_ev1_top6_" +cutVar.first).c_str(), ("h_jmt_ev1_top6_" +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_jmt_ev2_top6_" +cutVar.first, std::make_shared<TH1D> ( ("h_jmt_ev2_top6_" +cutVar.first).c_str(), ("h_jmt_ev2_top6_" +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_event_beta_z_" +cutVar.first, std::make_shared<TH1D> ( ("h_event_beta_z_" +cutVar.first).c_str(), ("h_event_beta_z_" +cutVar.first).c_str(), 1440, -1, 1       ) );
+        // 2D histograms
+        my_2d_histos.emplace( "h_jet_EtaVsPhi_"     +cutVar.first, std::make_shared<TH2D>( ("h_jet_EtaVsPhi_"     +cutVar.first).c_str(), ("h_jet_EtaVsPhi_"     +cutVar.first).c_str(), 1440, -2.5, 2.5, 1440, -3.14, 3.14 ) );
+        my_2d_histos.emplace( "h_electron_EtaVsPhi_"+cutVar.first, std::make_shared<TH2D>( ("h_electron_EtaVsPhi_"+cutVar.first).c_str(), ("h_electron_EtaVsPhi_"+cutVar.first).c_str(), 1440, -2.5, 2.5, 1440, -3.14, 3.14 ) );
+        my_2d_histos.emplace( "h_muon_EtaVsPhi_"    +cutVar.first, std::make_shared<TH2D>( ("h_muon_EtaVsPhi_"    +cutVar.first).c_str(), ("h_muon_EtaVsPhi_"    +cutVar.first).c_str(), 1440, -2.5, 2.5, 1440, -3.14, 3.14 ) );
+
+        // ---------------
+        // after HEM issue
+        // ---------------
+        // 1D histograms
+        my_histos.emplace( "h_njets_HEM_"        +cutVar.first, std::make_shared<TH1D> ( ("h_njets_HEM_"        +cutVar.first).c_str(), ("h_njets_HEM_"        +cutVar.first).c_str(), 13, 6.5, 19.5     ) );
+        my_histos.emplace( "h_nbjets_HEM_"       +cutVar.first, std::make_shared<TH1D> ( ("h_nbjets_HEM_"       +cutVar.first).c_str(), ("h_nbjets_HEM_"       +cutVar.first).c_str(), 15, -0.5, 14.5    ) );
+        my_histos.emplace( "h_met_HEM_"          +cutVar.first, std::make_shared<TH1D> ( ("h_met_HEM_"          +cutVar.first).c_str(), ("h_met_HEM_"          +cutVar.first).c_str(), 720, 0, 1500      ) );
+        my_histos.emplace( "h_ht_HEM_"           +cutVar.first, std::make_shared<TH1D> ( ("h_ht_HEM_"           +cutVar.first).c_str(), ("h_ht_HEM_"           +cutVar.first).c_str(), 720, 300, 5000    ) );
+        my_histos.emplace( "h_jetPt_HEM_"        +cutVar.first, std::make_shared<TH1D> ( ("h_jetPt_HEM_"        +cutVar.first).c_str(), ("h_jetPt_HEM_"        +cutVar.first).c_str(), 1440, 0, 5000     ) );
+        my_histos.emplace( "h_jetPtMax_HEM_"     +cutVar.first, std::make_shared<TH1D> ( ("h_jetPtMax_HEM_"     +cutVar.first).c_str(), ("h_jetPtMax_HEM_"     +cutVar.first).c_str(), 1440, 0, 5000     ) );
+        my_histos.emplace( "h_lvMET_cm_mass_HEM_"+cutVar.first, std::make_shared<TH1D> ( ("h_lvMET_cm_mass_HEM_"+cutVar.first).c_str(), ("h_lvMET_cm_mass_HEM_"+cutVar.first).c_str(), 1440, 0, 1000     ) );
+        my_histos.emplace( "h_lvMET_cm_eta_HEM_" +cutVar.first, std::make_shared<TH1D> ( ("h_lvMET_cm_eta_HEM_" +cutVar.first).c_str(), ("h_lvMET_cm_eta_HEM_" +cutVar.first).c_str(), 1440, -2.5, 2.5   ) );
+        my_histos.emplace( "h_lvMET_cm_phi_HEM_" +cutVar.first, std::make_shared<TH1D> ( ("h_lvMET_cm_phi_HEM_" +cutVar.first).c_str(), ("h_lvMET_cm_phi_HEM_" +cutVar.first).c_str(), 1440, -3.14, 3.14 ) );
+        my_histos.emplace( "h_lvMET_cm_pt_HEM_"  +cutVar.first, std::make_shared<TH1D> ( ("h_lvMET_cm_pt_HEM_"  +cutVar.first).c_str(), ("h_lvMET_cm_pt_HEM_"  +cutVar.first).c_str(), 1440, 0, 1000     ) );
+        my_histos.emplace( "h_fwm2_top6_HEM_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm2_top6_HEM_"    +cutVar.first).c_str(), ("h_fwm2_top6_HEM_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm3_top6_HEM_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm3_top6_HEM_"    +cutVar.first).c_str(), ("h_fwm3_top6_HEM_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm4_top6_HEM_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm4_top6_HEM_"    +cutVar.first).c_str(), ("h_fwm4_top6_HEM_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm5_top6_HEM_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm5_top6_HEM_"    +cutVar.first).c_str(), ("h_fwm5_top6_HEM_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm6_top6_HEM_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm6_top6_HEM_"    +cutVar.first).c_str(), ("h_fwm6_top6_HEM_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm7_top6_HEM_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm7_top6_HEM_"    +cutVar.first).c_str(), ("h_fwm7_top6_HEM_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm8_top6_HEM_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm8_top6_HEM_"    +cutVar.first).c_str(), ("h_fwm8_top6_HEM_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm9_top6_HEM_"    +cutVar.first, std::make_shared<TH1D> ( ("h_fwm9_top6_HEM_"    +cutVar.first).c_str(), ("h_fwm9_top6_HEM_"    +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_fwm10_top6_HEM_"   +cutVar.first, std::make_shared<TH1D> ( ("h_fwm10_top6_HEM_"   +cutVar.first).c_str(), ("h_fwm10_top6_HEM_"   +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_jmt_ev0_top6_HEM_" +cutVar.first, std::make_shared<TH1D> ( ("h_jmt_ev0_top6_HEM_" +cutVar.first).c_str(), ("h_jmt_ev0_top6_HEM_" +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_jmt_ev1_top6_HEM_" +cutVar.first, std::make_shared<TH1D> ( ("h_jmt_ev1_top6_HEM_" +cutVar.first).c_str(), ("h_jmt_ev1_top6_HEM_" +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_jmt_ev2_top6_HEM_" +cutVar.first, std::make_shared<TH1D> ( ("h_jmt_ev2_top6_HEM_" +cutVar.first).c_str(), ("h_jmt_ev2_top6_HEM_" +cutVar.first).c_str(), 1440, 0, 1        ) );
+        my_histos.emplace( "h_event_beta_z_HEM_" +cutVar.first, std::make_shared<TH1D> ( ("h_event_beta_z_HEM_" +cutVar.first).c_str(), ("h_event_beta_z_HEM_" +cutVar.first).c_str(), 1440, -1, 1       ) ); 
+        // 2D histograms
+        my_2d_histos.emplace( "h_jet_EtaVsPhi_HEM_"     +cutVar.first, std::make_shared<TH2D>( ("h_jet_EtaVsPhi_HEM_"     +cutVar.first).c_str(), ("h_jet_EtaVsPhi_HEM_"     +cutVar.first).c_str(), 1440, -2.5, 2.5, 1440, -3.14, 3.14 ) );
+        my_2d_histos.emplace( "h_electron_EtaVsPhi_HEM_"+cutVar.first, std::make_shared<TH2D>( ("h_electron_EtaVsPhi_HEM_"+cutVar.first).c_str(), ("h_electron_EtaVsPhi_HEM_"+cutVar.first).c_str(), 1440, -2.5, 2.5, 1440, -3.14, 3.14 ) );
+        my_2d_histos.emplace( "h_muon_EtaVsPhi_HEM_"    +cutVar.first, std::make_shared<TH2D>( ("h_muon_EtaVsPhi_HEM_"    +cutVar.first).c_str(), ("h_muon_EtaVsPhi_HEM_"    +cutVar.first).c_str(), 1440, -2.5, 2.5, 1440, -3.14, 3.14 ) );
+
+    }
+}
+
+// ---------------------------------------------
+// -- Put everything you want to do per event 
+// ---------------------------------------------
+void HEM_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
+{
+    while( tr.getNextEvent() )
+    {
+        
+        const auto& eventCounter = tr.getVar<int>("eventCounter");
+
+        // ------------------------
+        // -- Print Event Number 
+        // ------------------------
+        if( maxevents != -1 && tr.getEvtNum() >= maxevents ) break;
+        if( tr.getEvtNum() & (10000 == 0) ) printf( " Event %i\n", tr.getEvtNum() );
+
+        const auto& runtype         = tr.getVar<std::string>("runtype");     
+        const auto& RunNum          = tr.getVar<unsigned int>("RunNum");
+        const auto& Jets            = tr.getVec<utility::LorentzVector>("Jets");
+        const auto& GoodLeptons     = tr.getVec<std::pair<std::string, utility::LorentzVector>>("GoodLeptons");
+        const auto& GoodJets_pt30   = tr.getVec<bool>("GoodJets_pt30");
+        const auto& NGoodLeptons    = tr.getVar<int>("NGoodLeptons");
+        const auto& NGoodJets_pt30  = tr.getVar<int>("NGoodJets_pt30");
+        const auto& NGoodBJets_pt30 = tr.getVar<int>("NGoodBJets_pt30");
+        const auto& HT_trigger_pt30 = tr.getVar<double>("HT_trigger_pt30");
+        const auto& met             = tr.getVar<float>("MET");
+        const auto& lvMET_cm_m      = tr.getVar<double>("lvMET_cm_m");
+        const auto& lvMET_cm_eta    = tr.getVar<double>("lvMET_cm_eta");
+        const auto& lvMET_cm_phi    = tr.getVar<double>("lvMET_cm_phi");
+        const auto& lvMET_cm_pt     = tr.getVar<double>("lvMET_cm_pt");
+        const auto& fwm2_top6       = tr.getVar<double>("fwm2_top6");
+        const auto& fwm3_top6       = tr.getVar<double>("fwm3_top6");
+        const auto& fwm4_top6       = tr.getVar<double>("fwm4_top6");
+        const auto& fwm5_top6       = tr.getVar<double>("fwm5_top6");
+        const auto& fwm6_top6       = tr.getVar<double>("fwm6_top6");
+        const auto& fwm7_top6       = tr.getVar<double>("fwm7_top6");
+        const auto& fwm8_top6       = tr.getVar<double>("fwm8_top6");
+        const auto& fwm9_top6       = tr.getVar<double>("fwm9_top6");
+        const auto& fwm10_top6      = tr.getVar<double>("fwm10_top6");
+        const auto& jmt_ev0_top6    = tr.getVar<double>("jmt_ev0_top6");
+        const auto& jmt_ev1_top6    = tr.getVar<double>("jmt_ev1_top6");
+        const auto& jmt_ev2_top6    = tr.getVar<double>("jmt_ev2_top6");
+        const auto& event_beta_z    = tr.getVar<double>("event_beta_z");
+        const auto& passMadHT       = tr.getVar<bool>("passMadHT");
+        const auto& passBaseline_0l = tr.getVar<bool>("passBaseline0l_good");
+        const auto& passBaseline_1l = tr.getVar<bool>("passBaseline1l_Good");
+
+        // -------------------
+        // -- Define weight
+        // -------------------
+        double weight               = 1.0;
+        double eventweight          = 1.0;
+        double bTagScaleFactor      = 1.0;
+        double puScaleFactor        = 1.0;
+        double prefiringScaleFactor = 1.0;
+
+        double leptonScaleFactor    = 1.0;
+        double htDerivedScaleFactor = 1.0;
+        
+        if(runtype == "MC")
+        {
+            if( !passMadHT ) continue; // for 1l, Make sure not to double count DY events
+            // Define Lumi weight
+            const auto& lumi     = tr.getVar<double>("Lumi");
+            const auto& Weight   = tr.getVar<float>("Weight");
+            eventweight          = lumi*Weight;
+            //bTagScaleFactor      = tr.getVar<double>("bTagSF_EventWeightSimple_Central");
+            //puScaleFactor        = tr.getVar<double>("puWeightCorr");
+            //prefiringScaleFactor = tr.getVar<double>("prefiringScaleFactor");
+
+            // Define lepton weight
+            //if(NGoodLeptons == 1)
+            //{
+            //    const auto& eleLepWeight = tr.getVar<double>("totGoodElectronSF");
+            //    const auto& muLepWeight  = tr.getVar<double>("totGoodMuonSF");
+            //    leptonScaleFactor = (GoodLeptons[0].first == "e") ? eleLepWeight : muLepWeight;
+            //}
+    
+            //htDerivedScaleFactor = tr.getVar<double>("htDerivedweight");
+            //weight *= eventweight*leptonScaleFactor*bTagScaleFactor*htDerivedScaleFactor*prefiringScaleFactor*puScaleFactor;
+
+            weight *= eventweight;
+        }
+
+        // -------------------------------------------------
+        // -- Make cuts and fill histograms here & cutmap
+        // -------------------------------------------------
+        const std::map<std::string, bool>& cutmap
+        {
+            {"passBaseline_0l", passBaseline_0l},
+            {"passBaseline_1l", passBaseline_1l}, 
+
+        };
+
+        if (!inithisto) 
+        {
+            InitHistos(cutmap);
+            inithisto = true;
+        }
+
+        my_histos["EventCounter"]->Fill( eventCounter );
+
+        // --------------------------------
+        // -- Fill the cutmap histograms
+        // --------------------------------     
+        for (const auto& cutVar: cutmap) 
+        {    
+            if (cutVar.second) 
+            {
+                double jetPtMax = 0.0;
+                
+                // ----------------                
+                // before HEM issue
+                // ----------------
+                if ( RunNum < 319077 ) 
+                {
+                    for (unsigned int goodJet = 0; goodJet < Jets.size(); goodJet++) 
+                    {
+                        if (!GoodJets_pt30[goodJet]) { continue; }
+                            my_histos["h_jetPt_"          +cutVar.first]->Fill( Jets[goodJet].Pt(), weight               );
+                            my_2d_histos["h_jet_EtaVsPhi_"+cutVar.first]->Fill( Jets[goodJet].Eta(), Jets[goodJet].Phi() ); 
+
+                        if (Jets[goodJet].Pt() > jetPtMax) 
+                        { jetPtMax = Jets[goodJet].Pt(); }
+                    }
+        
+                    if (cutVar.first == "passBaseline_1l") 
+                    {    
+                        for (unsigned int goodLep = 0; goodLep < GoodLeptons.size(); goodLep++) 
+                        {
+                            if (GoodLeptons[goodLep].first == "e") 
+                            {
+                                my_2d_histos["h_electron_EtaVsPhi_"+cutVar.first]->Fill(GoodLeptons[goodLep].second.Eta(), GoodLeptons[goodLep].second.Phi());
+                            } 
+                            else 
+                            {
+                                my_2d_histos["h_muon_EtaVsPhi_"+cutVar.first]->Fill(GoodLeptons[goodLep].second.Eta(), GoodLeptons[goodLep].second.Phi());
+                            }
+                        }        
+                    }          
+ 
+                    my_histos["h_njets_"        +cutVar.first]->Fill( NGoodJets_pt30, weight  );   
+                    my_histos["h_nbjets_"       +cutVar.first]->Fill( NGoodBJets_pt30, weight ); 
+                    my_histos["h_met_"          +cutVar.first]->Fill( met, weight             );
+                    my_histos["h_ht_"           +cutVar.first]->Fill( HT_trigger_pt30, weight );      
+                    my_histos["h_jetPtMax_"     +cutVar.first]->Fill( jetPtMax, weight        ); // same for 0l & 1l
+                    my_histos["h_lvMET_cm_mass_"+cutVar.first]->Fill( lvMET_cm_m, weight      );                    
+                    my_histos["h_lvMET_cm_eta_" +cutVar.first]->Fill( lvMET_cm_eta, weight    );
+                    my_histos["h_lvMET_cm_phi_" +cutVar.first]->Fill( lvMET_cm_phi, weight    );
+                    my_histos["h_lvMET_cm_pt_"  +cutVar.first]->Fill( lvMET_cm_pt, weight     );
+                    my_histos["h_fwm2_top6_"    +cutVar.first]->Fill( fwm2_top6, weight       );
+                    my_histos["h_fwm3_top6_"    +cutVar.first]->Fill( fwm3_top6, weight       );
+                    my_histos["h_fwm4_top6_"    +cutVar.first]->Fill( fwm4_top6, weight       );
+                    my_histos["h_fwm5_top6_"    +cutVar.first]->Fill( fwm5_top6, weight       );
+                    my_histos["h_fwm6_top6_"    +cutVar.first]->Fill( fwm6_top6, weight       );
+                    my_histos["h_fwm7_top6_"    +cutVar.first]->Fill( fwm7_top6, weight       );
+                    my_histos["h_fwm8_top6_"    +cutVar.first]->Fill( fwm8_top6, weight       );
+                    my_histos["h_fwm9_top6_"    +cutVar.first]->Fill( fwm9_top6, weight       );
+                    my_histos["h_fwm10_top6_"   +cutVar.first]->Fill( fwm10_top6, weight      );
+                    my_histos["h_jmt_ev0_top6_" +cutVar.first]->Fill( jmt_ev0_top6, weight    );
+                    my_histos["h_jmt_ev1_top6_" +cutVar.first]->Fill( jmt_ev1_top6, weight    );
+                    my_histos["h_jmt_ev2_top6_" +cutVar.first]->Fill( jmt_ev2_top6, weight    );
+                    my_histos["h_event_beta_z_" +cutVar.first]->Fill( event_beta_z, weight    );
+
+                }
+
+                // --------------- 
+                // after HEM issue
+                // --------------- 
+                else 
+                {
+                    for (unsigned int goodJet = 0; goodJet < Jets.size(); goodJet++)
+                    {
+                        if (!GoodJets_pt30[goodJet]) { continue; }
+                            my_histos["h_jetPt_HEM_"          +cutVar.first]->Fill( Jets[goodJet].Pt(), weight               );
+                            my_2d_histos["h_jet_EtaVsPhi_HEM_"+cutVar.first]->Fill( Jets[goodJet].Eta(), Jets[goodJet].Phi() );
+
+                        if (Jets[goodJet].Pt() > jetPtMax)
+                        { jetPtMax = Jets[goodJet].Pt(); }
+                    }
+
+                    if (cutVar.first == "1l")
+                    {
+                        for (unsigned int goodLep = 0; goodLep < GoodLeptons.size(); goodLep++)
+                        {
+                            if (GoodLeptons[goodLep].first == "e")
+                            {
+                                my_2d_histos["h_electron_EtaVsPhi_HEM_"+cutVar.first]->Fill(GoodLeptons[goodLep].second.Eta(), GoodLeptons[goodLep].second.Phi());
+                            }
+                            else
+                            {
+                                my_2d_histos["h_muon_EtaVsPhi_HEM_"+cutVar.first]->Fill(GoodLeptons[goodLep].second.Eta(), GoodLeptons[goodLep].second.Phi());
+                            }
+                        }
+                    }
+
+                    my_histos["h_njets_HEM_"        +cutVar.first]->Fill( NGoodJets_pt30, weight  );
+                    my_histos["h_nbjets_HEM_"       +cutVar.first]->Fill( NGoodBJets_pt30, weight );
+                    my_histos["h_met_HEM_"          +cutVar.first]->Fill( met, weight             );
+                    my_histos["h_ht_HEM_"           +cutVar.first]->Fill( HT_trigger_pt30, weight );
+                    my_histos["h_jetPtMax_HEM_"     +cutVar.first]->Fill( jetPtMax, weight        ); // same for 0l & 1l                    
+                    my_histos["h_lvMET_cm_mass_HEM_"+cutVar.first]->Fill( lvMET_cm_m, weight      );
+                    my_histos["h_lvMET_cm_eta_HEM_" +cutVar.first]->Fill( lvMET_cm_eta, weight    );
+                    my_histos["h_lvMET_cm_phi_HEM_" +cutVar.first]->Fill( lvMET_cm_phi, weight    );
+                    my_histos["h_lvMET_cm_pt_HEM_"  +cutVar.first]->Fill( lvMET_cm_pt, weight     );
+                    my_histos["h_fwm2_top6_HEM_"    +cutVar.first]->Fill( fwm2_top6, weight       );
+                    my_histos["h_fwm3_top6_HEM_"    +cutVar.first]->Fill( fwm3_top6, weight       );
+                    my_histos["h_fwm4_top6_HEM_"    +cutVar.first]->Fill( fwm4_top6, weight       );
+                    my_histos["h_fwm5_top6_HEM_"    +cutVar.first]->Fill( fwm5_top6, weight       );
+                    my_histos["h_fwm6_top6_HEM_"    +cutVar.first]->Fill( fwm6_top6, weight       );
+                    my_histos["h_fwm7_top6_HEM_"    +cutVar.first]->Fill( fwm7_top6, weight       );
+                    my_histos["h_fwm8_top6_HEM_"    +cutVar.first]->Fill( fwm8_top6, weight       );
+                    my_histos["h_fwm9_top6_HEM_"    +cutVar.first]->Fill( fwm9_top6, weight       );
+                    my_histos["h_fwm10_top6_HEM_"   +cutVar.first]->Fill( fwm10_top6, weight      );
+                    my_histos["h_jmt_ev0_top6_HEM_" +cutVar.first]->Fill( jmt_ev0_top6, weight    );
+                    my_histos["h_jmt_ev1_top6_HEM_" +cutVar.first]->Fill( jmt_ev1_top6, weight    );
+                    my_histos["h_jmt_ev2_top6_HEM_" +cutVar.first]->Fill( jmt_ev2_top6, weight    );
+                    my_histos["h_event_beta_z_HEM_" +cutVar.first]->Fill( event_beta_z, weight    );
+                }
+
+            }
+            
+        }
+    } 
+}
+
+void HEM_Analyzer::WriteHistos(TFile* outfile)
+{
+    outfile->cd();
+
+    for (const auto &p : my_histos) {
+        p.second->Write();
+    }
+ 
+    for (const auto &p : my_2d_histos) {
+        p.second->Write();
+    }
+
+}

--- a/Analyzer/src/HEM_Analyzer.cc
+++ b/Analyzer/src/HEM_Analyzer.cc
@@ -278,7 +278,7 @@ void HEM_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
                         { jetPtMax = Jets[goodJet].Pt(); }
                     }
 
-                    if (cutVar.first == "1l")
+                    if (cutVar.first == "passBaseline_1l")
                     {
                         for (unsigned int goodLep = 0; goodLep < GoodLeptons.size(); goodLep++)
                         {

--- a/Analyzer/test/HEM_Plotter.py
+++ b/Analyzer/test/HEM_Plotter.py
@@ -1,0 +1,352 @@
+import os 
+import sys
+import ROOT
+import argparse
+
+
+# -------------------------------------------------
+# make up the histograms such as rebin, title, etc.
+# -------------------------------------------------
+def do_Options(histo, histoName, theMap):
+
+    is1D = "TH1" in histo.ClassName()
+
+    for axis, options in theMap[histoName].iteritems():
+
+        # x-axis
+        if axis == "X":
+
+            if "rebin" in options:
+                if is1D: 
+                    histo.Rebin(options["rebin"])
+                else: 
+                    histo.RebinX(options["rebin"])
+
+            if "min" in options and "max" in options: 
+                histo.GetXaxis().SetRangeUser(options["min"],options["max"])
+
+            if "title" in options: 
+                histo.GetXaxis().SetTitle(options["title"])
+
+        #y-axis
+        if axis == "Y":
+
+            if "rebin" in options:
+                if is1D: 
+                    histo.Rebin(options["rebin"])
+                else: 
+                    histo.RebinY(options["rebin"])
+
+            if "min" in options and "max" in options: 
+                histo.GetYaxis().SetRangeUser(options["min"],options["max"])
+
+            if "title" in options: 
+                histo.GetYaxis().SetTitle(options["title"])
+
+        #z-axis
+        if axis == "Z":
+
+            if "min" in options and "max" in options: 
+                histo.GetZaxis().SetRangeUser(options["min"],options["max"])
+
+# ---------------------
+# update all font sizes
+# ---------------------
+def pretty_Histo(histo,magicFactor=1.0,magicFactor2=1.0):
+   
+    histo.GetXaxis().SetLabelSize(magicFactor*0.055)
+    histo.GetXaxis().SetTitleSize(magicFactor*0.08)
+    histo.GetXaxis().SetTitleOffset(0.7/magicFactor2)
+ 
+    histo.GetYaxis().SetLabelSize(magicFactor*0.055)
+    histo.GetYaxis().SetTitleSize(magicFactor*0.08)
+    histo.GetYaxis().SetTitleOffset(0.6/magicFactor)
+
+    histo.GetZaxis().SetLabelSize(magicFactor*0.055)
+    histo.GetZaxis().SetTitleSize(magicFactor*0.06)
+
+# --------------------------------------
+# get the histograms
+# make a dictionary for putting all them
+#   -- with/without HEM labels
+#   -- with 0l/1l labels
+# --------------------------------------
+def fill_Map(inRootDir, theMap):
+
+    theMap["HEM"]   = {}
+    theMap["NOHEM"] = {}
+
+    for histoFile in os.listdir(inRootDir):
+
+        if ".root" not in histoFile: continue
+        
+        histoFile = ROOT.TFile.Open(inRootDir + histoFile, "READ")
+        
+        for hkey in histoFile.GetListOfKeys():
+            if "TH" not in hkey.GetClassName(): continue
+
+            if hkey.GetName() == "EventCounter": continue
+
+            keyName = ""
+            if "HEM" in hkey.GetName(): 
+                keyName = "HEM"
+            else: 
+                keyName = "NOHEM"
+
+            name  = hkey.GetName()
+            name  = name.replace("_HEM","")
+            histo = hkey.ReadObj()
+            histo.SetDirectory(0)
+            histo.Sumw2()
+           
+            if name in theMap[keyName].keys(): 
+                theMap[keyName][name].Add(histo)
+            else: 
+                theMap[keyName][name] = histo
+
+
+
+if __name__ == '__main__':
+
+    # --------------------------
+    # make sure about statistics
+    # --------------------------
+    ROOT.TH1.SetDefaultSumw2()
+    ROOT.gROOT.SetBatch(True)
+    ROOT.gStyle.SetOptStat("")
+    ROOT.gStyle.SetLineWidth(2)
+    ROOT.gStyle.SetPaintTextFormat("3.2f")
+    ROOT.gStyle.SetFrameLineWidth(2)
+    ROOT.gStyle.SetErrorX(0)
+
+    # --------------------
+    # command line options
+    # --------------------
+    usage  = "usage: %prog [options]"
+    parser = argparse.ArgumentParser(usage)
+    parser.add_argument("--tag",   dest="tag",   help="output dir tag",                    default="",     type=str)
+    parser.add_argument("--data",  dest="data",  help="JetHT, SingleElectron, SingleMuon", default="NULL", type=str)
+    parser.add_argument("--ratio", dest="ratio", help="Draw ratio", action="store_true",   default=False           )
+    
+    arg = parser.parse_args()
+
+    # --------------------
+    # make histograms list
+    # --------------------
+    optionsMap = {
+            "h_njets"           : {"X" : {"rebin" : 1,                          "title" : "N_{jets}"             }},
+            "h_nbjets"          : {"X" : {"rebin" : 1,                          "title" : "N_{bjets}"            }},
+            "h_ht"              : {"X" : {"rebin" : 5, "min" : 0, "max" : 2500, "title" : "H_{T} [GeV]"          }},
+            "h_met"             : {"X" : {"rebin" : 4, "min" : 0, "max" : 600,  "title" : "MET [GeV]"            }},
+            "h_jetPt"           : {"X" : {"rebin" : 5, "min" : 0, "max" : 1000, "title" : "Jet p_{T} [GeV]"      }},
+            "h_jetPtMax"        : {"X" : {"rebin" : 5, "min" : 0, "max" : 1000, "title" : "Max Jet p_{T} [GeV]"  }},
+            "h_lvMET_cm_mass"   : {"X" : {"rebin" : 1, "min" : 0, "max" : 1000, "title" : "Mass [GeV]"           }},
+            "h_lvMET_cm_eta"    : {"X" : {"rebin" : 1, "min" : 0, "max" : 1000, "title" : "#eta [GeV]"           }},
+            "h_lvMET_cm_phi"    : {"X" : {"rebin" : 1, "min" : 0, "max" : 1000, "title" : "#phi [GeV]"           }},
+            "h_lvMET_cm_pt"     : {"X" : {"rebin" : 1, "min" : 0, "max" : 1000, "title" : "p_{T} [GeV]"          }},
+            "h_fwm2_top6"       : {"X" : {"rebin" : 30                                                           }},
+            "h_fwm3_top6"       : {"X" : {"rebin" : 30                                                           }},
+            "h_fwm4_top6"       : {"X" : {"rebin" : 30                                                           }},
+            "h_fwm5_top6"       : {"X" : {"rebin" : 30                                                           }},
+            "h_fwm6_top6"       : {"X" : {"rebin" : 30                                                           }},
+            "h_fwm7_top6"       : {"X" : {"rebin" : 30                                                           }},
+            "h_fwm8_top6"       : {"X" : {"rebin" : 30                                                           }},
+            "h_fwm9_top6"       : {"X" : {"rebin" : 30                                                           }},
+            "h_fwm10_top6"      : {"X" : {"rebin" : 30                                                           }},
+            "h_jmt_ev0_top6"    : {"X" : {"rebin" : 30                                                           }},
+            "h_jmt_ev1_top6"    : {"X" : {"rebin" : 30                                                           }},
+            "h_jmt_ev2_top6"    : {"X" : {"rebin" : 30                                                           }},
+            "h_lvMET_cm_m"      : {"X" : {"rebin" : 30, "title" : "Mass [GeV]"                                   }},
+            "h_lvMET_cm_phi"    : {"X" : {"rebin" : 30, "title" : "#phi"                                         }},
+            "h_lvMET_cm_eta"    : {"X" : {"rebin" : 30, "title" : "#eta"                                         }},
+            "h_lvMET_cm_pt"     : {"X" : {"rebin" : 30, "title" : "p_{T} [GeV]"                                  }},
+            "h_beta_z"          : {"X" : {"rebin" : 30                                                           }},
+            "h_jet_etaphi"      : {"X" : {"rebin" : 360, "title" : "#eta"}, "Y" : {"rebin" : 80, "title" : "#phi"}},
+            "h_electron_etaphi" : {"X" : {"rebin" : 360, "title" : "#eta"}, "Y" : {"rebin" : 80, "title" : "#phi"}},
+            "h_muon_etaphi"     : {"X" : {"rebin" : 360, "title" : "#eta"}, "Y" : {"rebin" : 80, "title" : "#phi"}},
+    }
+
+    # -----------------------------------
+    # grab things for command line option
+    # -----------------------------------
+    ratio   = arg.ratio
+    XCANVAS = 2400; YCANVAS = 2400
+
+    if arg.data != "NULL": stub = arg.data.split("condor/")[-1]
+    else: quit()
+
+    tag       = arg.tag
+    inRootDir = arg.data
+    outpath   = "./plots/HEMStudy/%s/%s"%(stub,tag)
+    if not os.path.exists(outpath): os.makedirs(outpath)
+
+    mapPFAhistos = {}
+    fill_Map(inRootDir, mapPFAhistos)
+
+    # -------------------------
+    # Save the final histograms
+    # -------------------------
+    for name in mapPFAhistos.values()[0].keys():
+
+        if "0l" in name and "Single" in args.data: continue 
+
+        if "1l" in name and "JetHT" in args.data: continue
+
+        magicMargins = {"T" : 0.02625, "B" : 0.13375, "L" : 0.11, "R" : 0.12}
+
+        # -------------
+        # make 2D plots
+        # ------------- 
+        if "TH2" in mapPFAhistos.values()[0][name].ClassName():
+            
+            # -----------------------
+            # 2D plots with HEM issue
+            # -----------------------
+            c1 = ROOT.TCanvas("%s_HEM"%(name), "%s_HEM"%(name), XCANVAS, int(0.8*YCANVAS))
+            c1.cd()
+
+            ROOT.gPad.SetTopMargin(magicMargins["T"])
+            ROOT.gPad.SetBottomMargin(magicMargins["B"])
+            ROOT.gPad.SetLeftMargin(magicMargins["L"])
+            ROOT.gPad.SetRightMargin(magicMargins["R"])
+
+            theName = name.replace("_HEM","")
+            data1   = mapPFAhistos["HEM"][name]
+            data2   = mapPFAhistos["NOHEM"][name]
+
+            pretty_Histo(data1,0.875,0.8)
+            pretty_Histo(data2,0.875,0.8)
+
+            do_Options(data1, theName, optionsMap)
+            do_Options(data2, theName, optionsMap)
+
+            data1.SetTitle(""); data2.SetTitle("")
+            data1.SetContour(255); data2.SetContour(255)
+            data1.Draw("COLZ TEXT E")
+            c1.SaveAs("%s/%s_HEM.pdf"%(outpath,name))
+
+            # --------------------------
+            # 2D plots without HEM issue
+            # --------------------------
+            c2 = ROOT.TCanvas("%s_NOHEM"%(name), "%s_NOHEM"%(name), XCANVAS, int(0.8*YCANVAS))
+            c2.cd()
+
+            ROOT.gPad.SetTopMargin(magicMargins["T"])
+            ROOT.gPad.SetBottomMargin(magicMargins["B"])
+            ROOT.gPad.SetLeftMargin(magicMargins["L"])
+            ROOT.gPad.SetRightMargin(magicMargins["R"])
+
+            data2.Draw("COLZ TEXT E")
+            c2.SaveAs("%s/%s_NOHEM.pdf"%(outpath,name))
+
+            # -----------------------
+            # make ratio for 2D plots
+            # -----------------------
+            if data1.Integral() != 0:
+
+                c1 = ROOT.TCanvas("%s_ratio"%(name), "%s_ratio"%(name), XCANVAS, int(0.8*YCANVAS))
+                c1.cd()
+
+                ROOT.gPad.SetTopMargin(magicMargins["T"])
+                ROOT.gPad.SetBottomMargin(magicMargins["B"])
+                ROOT.gPad.SetLeftMargin(magicMargins["L"])
+                ROOT.gPad.SetRightMargin(magicMargins["R"])
+
+                data1.Scale(1./data1.Integral())
+                data2.Scale(1./data2.Integral())
+                data1.Divide(data2)
+                data1.GetZaxis().SetRangeUser(0.5,2.0)
+                data1.Draw("COLZ TEXT E")
+                c1.SaveAs("%s/%s_ratio.pdf"%(outpath,name))
+
+        # -------------
+        # make 1D plots
+        # -------------
+        elif "TH1" in mapPFAhistos.values()[0][name].ClassName():
+
+            if ratio:
+                XMin = 0;    XMax = 1; RatioXMin = 0; RatioXMax = 1 
+                YMin = 0.30; YMax = 1; RatioYMin = 0; RatioYMax = 0.30
+                PadFactor = (YMax-YMin) / (RatioYMax-RatioYMin)
+
+                c1 = ROOT.TCanvas("%s"%(name), "%s"%(name), XCANVAS, YCANVAS) 
+                c1.Divide(1,2)
+               
+                # -------------------------------------------
+                # superimpose the histograms with/without HEM
+                # -------------------------------------------
+                c1.cd(1)
+                ROOT.gPad.SetLogy()
+                ROOT.gPad.SetLogz()
+                ROOT.gPad.SetPad(XMin, YMin, XMax, YMax)
+                ROOT.gPad.SetGridy(); ROOT.gPad.SetGridx()
+                ROOT.gPad.SetTopMargin(0.03)
+                ROOT.gPad.SetLeftMargin(0.11)
+                ROOT.gPad.SetBottomMargin(0.02)
+                ROOT.gPad.SetRightMargin(0.04)
+
+                data1 = mapPFAhistos["HEM"][name]
+                data2 = mapPFAhistos["NOHEM"][name]
+                ratio = ROOT.TH1F("ratio_%s"%(name), "ratio_%s"%(name), data1.GetNbinsX(), data1.GetXaxis().GetXmin(), data1.GetXaxis().GetXmax()) 
+
+                pretty_Histo(data1)
+                pretty_Histo(data2)
+                pretty_Histo(ratio,PadFactor)
+
+                theName = data1.GetName().replace("_HEM", "")
+                if theName in optionsMap:
+
+                    do_Options(data1, theName, optionsMap)
+                    do_Options(data2, theName, optionsMap)
+                    do_Options(ratio, theName, optionsMap)
+
+                data2.SetMarkerColor(ROOT.kBlack)
+                data2.SetLineColor(ROOT.kBlack)
+                data2.SetMarkerSize(3)
+                data2.SetLineWidth(2)
+                data2.SetMarkerStyle(20)
+                data1.SetMarkerColor(ROOT.kRed)
+                data1.SetLineColor(ROOT.kRed)
+                data1.SetMarkerSize(3)
+                data1.SetLineWidth(2)
+                data1.SetMarkerStyle(20)
+                data2.SetTitle("")
+                data1.SetTitle("")
+
+                data1.Scale(1./data1.Integral())
+                data2.Scale(1./data2.Integral())
+                #data1.GetYaxis().SetRangeUser(0.001,1.1*data1.GetMaximum())
+                data1.GetXaxis().SetLabelSize(0)
+                data1.Draw("EP")
+                data2.Draw("EP SAME")
+
+                # ---------------------------------------------------
+                # put the ratio plot between with HEM and without HEM
+                # ---------------------------------------------------
+                c1.cd(2)
+
+                ROOT.gPad.SetGridy()
+                ROOT.gPad.SetTopMargin(0.10)
+                ROOT.gPad.SetBottomMargin(0.30)
+                ROOT.gPad.SetRightMargin(0.04)
+                ROOT.gPad.SetLeftMargin(0.11)
+                ROOT.gPad.SetPad(RatioXMin, RatioYMin, RatioXMax, RatioYMax)
+
+                ratio.SetTitle("")
+                ratio.Divide(data1,data2)
+
+                ratio.GetYaxis().SetRangeUser(0.50,1.5)
+                ratio.GetYaxis().SetNdivisions(-304)
+                ratio.GetYaxis().SetTitle("HEM / Nominal")
+                ratio.GetYaxis().SetTitleSize(ratio.GetYaxis().GetTitleSize()*0.6)
+                ratio.GetXaxis().SetTitleSize(ratio.GetXaxis().GetTitleSize()*0.8)
+                ratio.GetYaxis().SetTitleOffset(0.5)
+                ratio.GetXaxis().SetTitleOffset(0.9)
+                ratio.SetMarkerStyle(20); ratio.SetMarkerSize(3); ratio.SetMarkerColor(ROOT.kBlue+2)
+                ratio.SetLineWidth(2); ratio.SetLineColor(ROOT.kBlue+2)
+
+                ratio.Draw("EP")
+                c1.SaveAs("%s/%s.pdf"%(outpath,name))
+
+
+

--- a/Analyzer/test/HEM_Plotter.py
+++ b/Analyzer/test/HEM_Plotter.py
@@ -119,16 +119,19 @@ if __name__ == '__main__':
     ROOT.gStyle.SetFrameLineWidth(2)
     ROOT.gStyle.SetErrorX(0)
 
-    # --------------------
-    # command line options
-    # --------------------
+    # ---------------------------------------------------------------------------------------------------
+    # command line options:
+    #   -- python HEM_Plotter.py --inputDir 2018UL_HEMstudy_0l_1l --data JetHT --ratio          // for 0l
+    #   -- python HEM_Plotter.py --inputDir 2018UL_HEMstudy_0l_1l --data SingleElectron --ratio // for 1l
+    #   -- python HEM_Plotter.py --inputDir 2018UL_HEMstudy_0l_1l --data SingleMuon --ratio     // for 1l
+    # ---------------------------------------------------------------------------------------------------
     usage  = "usage: %prog [options]"
     parser = argparse.ArgumentParser(usage)
-    parser.add_argument("--tag",   dest="tag",   help="output dir tag",                    default="",     type=str)
-    parser.add_argument("--data",  dest="data",  help="JetHT, SingleElectron, SingleMuon", default="NULL", type=str)
-    parser.add_argument("--ratio", dest="ratio", help="Draw ratio", action="store_true",   default=False           )
+    parser.add_argument("--inputDir", dest="inputDir", help="input directory",                   default="",     type=str)
+    parser.add_argument("--data",     dest="data",     help="JetHT, SingleElectron, SingleMuon", default="NULL", type=str)
+    parser.add_argument("--ratio",    dest="ratio",    help="Draw ratio", action="store_true",   default=False           )
     
-    arg = parser.parse_args()
+    args = parser.parse_args()
 
     # --------------------
     # make histograms list
@@ -169,16 +172,15 @@ if __name__ == '__main__':
     # -----------------------------------
     # grab things for command line option
     # -----------------------------------
-    ratio   = arg.ratio
-    XCANVAS = 2400; YCANVAS = 2400
+    ratio   = args.ratio
+    XCANVAS = 2400
+    YCANVAS = 2400
 
-    if arg.data != "NULL": stub = arg.data.split("condor/")[-1]
-    else: quit()
-
-    tag       = arg.tag
-    inRootDir = arg.data
-    outpath   = "./plots/HEMStudy/%s/%s"%(stub,tag)
-    if not os.path.exists(outpath): os.makedirs(outpath)
+    inRootDir = args.inputDir
+    outpath   = "./2018UL_HEM_Study_0l_1l"
+    
+    if not os.path.exists(outpath): 
+        os.makedirs(outpath)
 
     mapPFAhistos = {}
     fill_Map(inRootDir, mapPFAhistos)

--- a/Analyzer/test/Makefile.in
+++ b/Analyzer/test/Makefile.in
@@ -63,8 +63,8 @@ PROGRAMS = $(ODIR)/rootdict.cc plot_1l Stack_plot_0l Stack_plot_1l Stack_plot_2l
 
 ANALYZERS  = $(ODIR)/MiniTupleMaker.o $(ODIR)/CalculateBTagSF.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/MakeMiniTree.o $(ODIR)/AnalyzeLepTrigger.o $(ODIR)/AnalyzeTest.o 
 ANALYZERS += $(ODIR)/MakeMiniTree.o $(ODIR)/MiniTupleMaker.o $(ODIR)/CalculateBTagSF.o $(ODIR)/AnalyzeBTagSF.o $(ODIR)/BTagCalibrationStandalone.o 
-ANALYZERS += $(ODIR)/ResolvedTopTagger_Analyzer.o $(ODIR)/AnalyzeXsec.o $(ODIR)/AnalyzeHEM.o $(ODIR)/MakeNNVariables.o $(ODIR)/AnalyzeDoubleDisCo.o $(ODIR)/AnalyzeGenStop.o
-ANALYZERS += $(ODIR)/Semra_Analyzer.o $(ODIR)/WholeTopTagger_Analyzer.o $(ODIR)/TopTaggerSF_Analyzer.o $(ODIR)/ISRJets_Analyzer.o $(ODIR)/HadTriggers_Analyzer.o $(ODIR)/TwoLepAnalyzer.o 
+ANALYZERS += $(ODIR)/AnalyzeXsec.o $(ODIR)/AnalyzeHEM.o $(ODIR)/MakeNNVariables.o $(ODIR)/AnalyzeDoubleDisCo.o $(ODIR)/AnalyzeGenStop.o
+ANALYZERS += $(ODIR)/Semra_Analyzer.o $(ODIR)/ResolvedTopTagger_Analyzer.o $(ODIR)/WholeTopTagger_Analyzer.o $(ODIR)/HEM_Analyzer.o $(ODIR)/TopTaggerSF_Analyzer.o $(ODIR)/ISRJets_Analyzer.o $(ODIR)/HadTriggers_Analyzer.o $(ODIR)/TwoLepAnalyzer.o 
 
 HELPERS  = $(ODIR)/NTupleReader.o $(ODIR)/Utility.o $(ODIR)/samples.o $(ODIR)/EventShapeVariables.o $(ODIR)/SetUpTopTagger.o $(ODIR)/NTRException.o $(ODIR)/histio.o 
 HELPERS += $(ODIR)/Make2LInputTrees.o $(ODIR)/Hemispheres.o $(ODIR)/StealthHemispheres.o 

--- a/Analyzer/test/MyAnalysis.C
+++ b/Analyzer/test/MyAnalysis.C
@@ -6,7 +6,6 @@
 
 #include "TopTagger/CfgParser/interface/TTException.h"
 
-#include "Analyzer/Analyzer/include/ResolvedTopTagger_Analyzer.h"
 #include "Analyzer/Analyzer/include/AnalyzeDoubleDisCo.h"
 #include "Analyzer/Analyzer/include/AnalyzeHEM.h"
 #include "Analyzer/Analyzer/include/AnalyzeTest.h"
@@ -18,7 +17,9 @@
 #include "Analyzer/Analyzer/include/CalculateSFMean.h"
 #include "Analyzer/Analyzer/include/Config.h"
 #include "Analyzer/Analyzer/include/Semra_Analyzer.h"
+#include "Analyzer/Analyzer/include/ResolvedTopTagger_Analyzer.h"
 #include "Analyzer/Analyzer/include/WholeTopTagger_Analyzer.h"
+#include "Analyzer/Analyzer/include/HEM_Analyzer.h"
 #include "Analyzer/Analyzer/include/TopTaggerSF_Analyzer.h"
 #include "Analyzer/Analyzer/include/ISRJets_Analyzer.h"
 #include "Analyzer/Analyzer/include/HadTriggers_Analyzer.h"
@@ -170,28 +171,29 @@ int main(int argc, char *argv[])
     TFile* outfile = TFile::Open(histFile.c_str(), "RECREATE");
 
     std::vector<std::pair<std::string, std::function<void(const std::set<AnaSamples::FileSummary>&,const int,const int,const int,TFile* const,const bool,const std::string&)>>> AnalyzerPairVec = {
+        {"AnalyzeDoubleDisCo",         run<AnalyzeDoubleDisCo>        },
+        {"AnalyzeLepTrigger",          run<AnalyzeLepTrigger>         },
+        {"AnalyzeBTagSF",              run<AnalyzeBTagSF>             },
+        {"AnalyzeHEM",                 run<AnalyzeHEM>                },
+        {"AnalyzeTest",                run<AnalyzeTest>               },
+        {"CalculateBTagSF",            run<CalculateBTagSF>           },
+        {"CalculateSFMean",            run<CalculateSFMean>           },
+        {"MakeMiniTree",               run<MakeMiniTree>              },
+        {"MakeNJetDists",              run<MakeNJetDists>             },
+        {"Semra_Analyzer",             run<Semra_Analyzer>            },
         {"ResolvedTopTagger_Analyzer", run<ResolvedTopTagger_Analyzer>},
-        {"AnalyzeDoubleDisCo",         run<AnalyzeDoubleDisCo>},
-        {"AnalyzeLepTrigger",          run<AnalyzeLepTrigger>},
-        {"AnalyzeBTagSF",              run<AnalyzeBTagSF>},
-        {"AnalyzeHEM",                 run<AnalyzeHEM>},
-        {"AnalyzeTest",                run<AnalyzeTest>},
-        {"CalculateBTagSF",            run<CalculateBTagSF>},
-        {"CalculateSFMean",            run<CalculateSFMean>},
-        {"MakeMiniTree",               run<MakeMiniTree>},
-        {"MakeNJetDists",              run<MakeNJetDists>},
-        {"Semra_Analyzer",             run<Semra_Analyzer>},
-        {"WholeTopTagger_Analyzer",    run<WholeTopTagger_Analyzer>},
-        {"TopTaggerSF_Analyzer",       run<TopTaggerSF_Analyzer>},
-        {"ISRJets_Analyzer",           run<ISRJets_Analyzer>},
-        {"HadTriggers_Analyzer",       run<HadTriggers_Analyzer>},
-        {"TwoLepAnalyzer",             run<TwoLepAnalyzer>},
-        {"Make2LInputTrees",           run<Make2LInputTrees>},
-        {"StealthHemispheres",         run<StealthHemispheres>},
-        {"AnalyzeTemplate",            run<AnalyzeTemplate>},
-        {"MakeNNVariables",            run<MakeNNVariables>},
-        {"AnalyzeGenStop",             run<AnalyzeGenStop>},
-        {"AnalyzeXsec",                run<AnalyzeXsec>}
+        {"WholeTopTagger_Analyzer",    run<WholeTopTagger_Analyzer>   },
+        {"HEM_Analyzer",               run<HEM_Analyzer>              },
+        {"TopTaggerSF_Analyzer",       run<TopTaggerSF_Analyzer>      },
+        {"ISRJets_Analyzer",           run<ISRJets_Analyzer>          },
+        {"HadTriggers_Analyzer",       run<HadTriggers_Analyzer>      },
+        {"TwoLepAnalyzer",             run<TwoLepAnalyzer>            },
+        {"Make2LInputTrees",           run<Make2LInputTrees>          },
+        {"StealthHemispheres",         run<StealthHemispheres>        },
+        {"AnalyzeTemplate",            run<AnalyzeTemplate>           },
+        {"MakeNNVariables",            run<MakeNNVariables>           },
+        {"AnalyzeGenStop",             run<AnalyzeGenStop>            },
+        {"AnalyzeXsec",                run<AnalyzeXsec>               }
 
     }; 
 


### PR DESCRIPTION
I made a new analyzer for 2018 UL HEM study:

1. **HEM_Analyzer.cc** 
    -- includes histograms for both preHEM and postHEM, so you send condor for just **2018** (**_not 2018pre and 2018post_**)
    -- includes histograms for both 0-lepton and 1-lepton channels
    -- **Note that** I didn't touch old version of this analyzer (**_AnalyzeHEM.cc_**)
2. **HEM_Plotter.py**
    -- get this plotter and update to make both 1D and 2D plots for HEM study

