### PR TITLE
Moving to shape based correction of btagSF

### DIFF
--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -160,7 +160,7 @@ public:
             //DoubleDisCo_Cfg_NonIsoMuon_2l = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_2l_2016.cfg";
             leptonFileName        = "allInOne_leptonSF_UL.root";
             bjetFileName          = "allInOne_BTagEff_UL.root";
-            bjetCSVFileName       = "wp_deepCSV_106XUL16preVFP_v2.csv";
+            bjetCSVFileName       = "reshaping_deepCSV_106XUL16preVFP_v2.csv";
             meanFileName          = "allInOne_SFMean_UL.root";
             blind                 = false;
             TopTaggerCfg          = "TopTaggerCfg_2016.cfg";
@@ -193,7 +193,7 @@ public:
             //DoubleDisCo_Cfg_NonIsoMuon_2l = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_2l_2016.cfg";
             leptonFileName        = "allInOne_leptonSF_UL.root";
             bjetFileName          = "allInOne_BTagEff_UL.root";
-            bjetCSVFileName       = "wp_deepCSV_106XUL16postVFP_v3.csv";
+            bjetCSVFileName       = "reshaping_deepCSV_106XUL16postVFP_v3.csv";
             meanFileName          = "allInOne_SFMean_UL.root";
             blind                 = false;
             TopTaggerCfg          = "TopTaggerCfg_2016.cfg";
@@ -227,7 +227,7 @@ public:
             //DoubleDisCo_Cfg_NonIsoMuon_2l = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_2l_2016.cfg";
             leptonFileName        = "allInOne_leptonSF_UL.root";
             bjetFileName          = "allInOne_BTagEff_UL.root";
-            bjetCSVFileName       = "wp_deepCSV_106XUL17_v3.csv";
+            bjetCSVFileName       = "reshaping_deepCSV_106XUL17_v3.csv";
             meanFileName          = "allInOne_SFMean_UL.root";
             blind                 = false;
             TopTaggerCfg          = "TopTaggerCfg_2017.cfg";
@@ -261,7 +261,7 @@ public:
             //DoubleDisCo_Cfg_NonIsoMuon_2l = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_2l_2016.cfg";
             leptonFileName        = "allInOne_leptonSF_UL.root";
             bjetFileName          = "allInOne_BTagEff_UL.root";
-            bjetCSVFileName       = "wp_deepCSV_106XUL18_v2.csv";
+            bjetCSVFileName       = "reshaping_deepCSV_106XUL18_v2.csv";
             meanFileName          = "allInOne_SFMean_UL.root";
             blind                 = false;
             TopTaggerCfg          = "TopTaggerCfg_2018.cfg";
@@ -295,7 +295,7 @@ public:
             //DoubleDisCo_Cfg_NonIsoMuon_2l = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_2l_2016.cfg";
             leptonFileName        = "allInOne_leptonSF_UL.root";
             bjetFileName          = "allInOne_BTagEff_UL.root";
-            bjetCSVFileName       = "wp_deepCSV_106XUL18_v2.csv";
+            bjetCSVFileName       = "reshaping_deepCSV_106XUL18_v2.csv";
             meanFileName          = "allInOne_SFMean_UL.root";
             blind                 = false;
             TopTaggerCfg          = "TopTaggerCfg_2018.cfg";
@@ -329,7 +329,7 @@ public:
             //DoubleDisCo_Cfg_NonIsoMuon_2l = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_2l_2016.cfg";
             leptonFileName        = "allInOne_leptonSF_UL.root";
             bjetFileName          = "allInOne_BTagEff_UL.root";
-            bjetCSVFileName       = "wp_deepCSV_106XUL18_v2.csv";
+            bjetCSVFileName       = "reshaping_deepCSV_106XUL18_v2.csv";
             meanFileName          = "allInOne_SFMean_UL.root";
             blind                 = false;
             TopTaggerCfg          = "TopTaggerCfg_2018.cfg";

--- a/Analyzer/test/condor/condorSubmit.py
+++ b/Analyzer/test/condor/condorSubmit.py
@@ -74,7 +74,7 @@ def main():
                        testDir + "/keras_frozen_DoubleDisCo_Reg_0l_SYY_2016.pb",
                        testDir + "/keras_frozen_DoubleDisCo_Reg_1l_SYY_2016.pb",
                        testDir + "/allInOne_BTagEff_UL.root",
-                       testDir + "/allInOne_SFMean.root",
+                       testDir + "/allInOne_SFMean_UL.root",
                        testDir + "/allInOne_leptonSF_UL.root",
                        testDir + "/PileupHistograms_0121_69p2mb_pm4p6.root",
                        testDir + "/pu_ratio.root",

--- a/Analyzer/test/setup.sh
+++ b/Analyzer/test/setup.sh
@@ -33,10 +33,10 @@ then
     echo "|--------------------------------------|"
     echo "|  Copying scale factor files          |"
     echo "|--------------------------------------|"
-    xrdcp -f root://cmseos.fnal.gov//store/user/bcrossma/StealthStop/ScaleFactorHistograms/FullRun2/wp_deepCSV_106XUL16preVFP_v2.csv .
-    xrdcp -f root://cmseos.fnal.gov//store/user/bcrossma/StealthStop/ScaleFactorHistograms/FullRun2/wp_deepCSV_106XUL16postVFP_v3.csv .
-    xrdcp -f root://cmseos.fnal.gov//store/user/bcrossma/StealthStop/ScaleFactorHistograms/FullRun2/wp_deepCSV_106XUL17_v3.csv .
-    xrdcp -f root://cmseos.fnal.gov//store/user/bcrossma/StealthStop/ScaleFactorHistograms/FullRun2/wp_deepCSV_106XUL18_v2.csv .
+    xrdcp -f root://cmseos.fnal.gov//store/user/bcrossma/StealthStop/ScaleFactorHistograms/FullRun2/reshaping_deepCSV_106XUL16postVFP_v3.csv .
+    xrdcp -f root://cmseos.fnal.gov//store/user/bcrossma/StealthStop/ScaleFactorHistograms/FullRun2/reshaping_deepCSV_106XUL16preVFP_v2.csv .
+    xrdcp -f root://cmseos.fnal.gov//store/user/bcrossma/StealthStop/ScaleFactorHistograms/FullRun2/reshaping_deepCSV_106XUL17_v3.csv .
+    xrdcp -f root://cmseos.fnal.gov//store/user/bcrossma/StealthStop/ScaleFactorHistograms/FullRun2/reshaping_deepCSV_106XUL18_v2.csv .
     xrdcp -f root://cmseos.fnal.gov//store/user/bcrossma/StealthStop/ScaleFactorHistograms/FullRun2/allInOne_leptonSF_UL.root .
     xrdcp -f root://cmseos.fnal.gov//store/user/bcrossma/StealthStop/ScaleFactorHistograms/FullRun2/allInOne_BTagEff_UL.root .
     xrdcp -f root://cmseos.fnal.gov//store/user/bcrossma/StealthStop/ScaleFactorHistograms/FullRun2/allInOne_SFMean_UL.root .


### PR DESCRIPTION
Added reshaping scale factors that will modify the shape of the b-tag discriminant (see [Twiki](https://twiki.cern.ch/twiki/bin/view/CMS/BTagShapeCalibration).

Changes:
- Updated `setup.sh` to pull the correct CSV files from my EOS area
- Changed names of CSV files in `Config.h`