### PR TITLE
Rework HEM Veto for UL

### DIFF
--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -130,7 +130,8 @@ public:
         //std::string DoubleDisCo_Cfg_2l, DoubleDisCo_Model_2l, DoubleDisCo_Cfg_NonIsoMuon_2l;      
         std::string leptonFileName, bjetFileName, bjetCSVFileName, meanFileName, TopTaggerCfg;
  
-        double Lumi=0.0, deepCSV_WP_loose=0.0, deepCSV_WP_medium=0.0, deepCSV_WP_tight=0.0;
+        double Lumi=0.0, Lumi_postHEM=-1.0, Lumi_preHEM=-1.0;
+        double deepCSV_WP_loose=0.0, deepCSV_WP_medium=0.0, deepCSV_WP_tight=0.0;
         bool blind = true;
 
         if(filetag.find("2016preVFP") != std::string::npos)
@@ -304,6 +305,8 @@ public:
         {
             runYear               = "2018";
             Lumi                  = 59830.0;
+            Lumi_preHEM           = 21071.0;
+            Lumi_postHEM          = 38654.0;
             deepCSV_WP_loose      = 0.1208;
             deepCSV_WP_medium     = 0.4168;       
             deepCSV_WP_tight      = 0.7665;
@@ -337,6 +340,8 @@ public:
 
         tr.registerDerivedVar("runYear",                           runYear                          );
         tr.registerDerivedVar("Lumi",                              Lumi                             );
+        tr.registerDerivedVar("Lumi_preHEM",                       Lumi_preHEM                      );
+        tr.registerDerivedVar("Lumi_postHEM",                      Lumi_postHEM                     );
         tr.registerDerivedVar("deepCSV_WP_loose",                  deepCSV_WP_loose                 );
         tr.registerDerivedVar("deepCSV_WP_medium",                 deepCSV_WP_medium                );
         tr.registerDerivedVar("deepCSV_WP_tight",                  deepCSV_WP_tight                 );

--- a/Analyzer/include/HEM_Analyzer.h
+++ b/Analyzer/include/HEM_Analyzer.h
@@ -3,7 +3,7 @@
 
 #include <TH1D.h>
 #include <TH2D.h>
-#include <TTree.h>
+#include <TFile.h>
 
 #include <map>
 #include <string>

--- a/Analyzer/src/HEM_Analyzer.cc
+++ b/Analyzer/src/HEM_Analyzer.cc
@@ -112,32 +112,33 @@ void HEM_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
         const auto& GoodLeptons           = tr.getVec<std::pair<std::string, utility::LorentzVector>>("GoodLeptons");
         const auto& GoodJets_pt30         = tr.getVec<bool>("GoodJets_pt30");
         const auto& GoodBJets_pt30        = tr.getVec<bool>("GoodBJets_pt30");
-        const auto& NGoodLeptons          = tr.getVar<int>("NGoodLeptons");
-        const auto& NGoodJets_pt30        = tr.getVar<int>("NGoodJets_pt30");
-        const auto& NGoodBJets_pt30       = tr.getVar<int>("NGoodBJets_pt30");
-        const auto& HT_trigger_pt30       = tr.getVar<double>("HT_trigger_pt30");
-        const auto& met                   = tr.getVar<float>("MET");
-        const auto& lvMET_cm_m            = tr.getVar<double>("lvMET_cm_m");
-        const auto& lvMET_cm_eta          = tr.getVar<double>("lvMET_cm_eta");
-        const auto& lvMET_cm_phi          = tr.getVar<double>("lvMET_cm_phi");
-        const auto& lvMET_cm_pt           = tr.getVar<double>("lvMET_cm_pt");
-        const auto& fwm2_top6             = tr.getVar<double>("fwm2_top6");
-        const auto& fwm3_top6             = tr.getVar<double>("fwm3_top6");
-        const auto& fwm4_top6             = tr.getVar<double>("fwm4_top6");
-        const auto& fwm5_top6             = tr.getVar<double>("fwm5_top6");
-        const auto& fwm6_top6             = tr.getVar<double>("fwm6_top6");
-        const auto& fwm7_top6             = tr.getVar<double>("fwm7_top6");
-        const auto& fwm8_top6             = tr.getVar<double>("fwm8_top6");
-        const auto& fwm9_top6             = tr.getVar<double>("fwm9_top6");
-        const auto& fwm10_top6            = tr.getVar<double>("fwm10_top6");
-        const auto& jmt_ev0_top6          = tr.getVar<double>("jmt_ev0_top6");
-        const auto& jmt_ev1_top6          = tr.getVar<double>("jmt_ev1_top6");
-        const auto& jmt_ev2_top6          = tr.getVar<double>("jmt_ev2_top6");
-        const auto& event_beta_z          = tr.getVar<double>("event_beta_z");
-        const auto& passMadHT             = tr.getVar<bool>("passMadHT");
-        const auto& passBaseline_0l       = tr.getVar<bool>("passBaseline0l_good");
-        const auto& passBaseline_1l       = tr.getVar<bool>("passBaseline1l_Good");
-        const auto& passElectronHEMVeto   = tr.getVar<bool>("passElectronHEMVeto");
+        const auto& NGoodLeptons            = tr.getVar<int>("NGoodLeptons");
+        const auto& NGoodJets_pt30          = tr.getVar<int>("NGoodJets_pt30");
+        const auto& NGoodBJets_pt30         = tr.getVar<int>("NGoodBJets_pt30");
+        const auto& HT_trigger_pt30         = tr.getVar<double>("HT_trigger_pt30");
+        const auto& met                     = tr.getVar<float>("MET");
+        const auto& lvMET_cm_m              = tr.getVar<double>("lvMET_cm_m");
+        const auto& lvMET_cm_eta            = tr.getVar<double>("lvMET_cm_eta");
+        const auto& lvMET_cm_phi            = tr.getVar<double>("lvMET_cm_phi");
+        const auto& lvMET_cm_pt             = tr.getVar<double>("lvMET_cm_pt");
+        const auto& fwm2_top6               = tr.getVar<double>("fwm2_top6");
+        const auto& fwm3_top6               = tr.getVar<double>("fwm3_top6");
+        const auto& fwm4_top6               = tr.getVar<double>("fwm4_top6");
+        const auto& fwm5_top6               = tr.getVar<double>("fwm5_top6");
+        const auto& fwm6_top6               = tr.getVar<double>("fwm6_top6");
+        const auto& fwm7_top6               = tr.getVar<double>("fwm7_top6");
+        const auto& fwm8_top6               = tr.getVar<double>("fwm8_top6");
+        const auto& fwm9_top6               = tr.getVar<double>("fwm9_top6");
+        const auto& fwm10_top6              = tr.getVar<double>("fwm10_top6");
+        const auto& jmt_ev0_top6            = tr.getVar<double>("jmt_ev0_top6");
+        const auto& jmt_ev1_top6            = tr.getVar<double>("jmt_ev1_top6");
+        const auto& jmt_ev2_top6            = tr.getVar<double>("jmt_ev2_top6");
+        const auto& event_beta_z            = tr.getVar<double>("event_beta_z");
+        const auto& passMadHT               = tr.getVar<bool>("passMadHT");
+        const auto& passBaseline_0l         = tr.getVar<bool>("passBaseline0l_good");
+        const auto& passBaseline_1l         = tr.getVar<bool>("passBaseline1l_Good");
+        const auto& passBaseline_0l_HEMveto = tr.getVar<bool>("passBaseline0l_good_HEMveto");
+        const auto& passBaseline_1l_HEMveto = tr.getVar<bool>("passBaseline1l_Good_HEMveto");
 
         // -------------------
         // -- Define weight
@@ -153,11 +154,7 @@ void HEM_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
         
         if(runtype == "MC")
         {
-            if( !passMadHT ) continue; // for 1l, Make sure not to double count DY events
-            // Define Lumi weight
-            const auto& lumi     = tr.getVar<double>("Lumi");
-            const auto& Weight   = tr.getVar<float>("Weight");
-            eventweight          = lumi*Weight;
+            eventweight          = tr.getVar<float>("LumiXsec");
             //bTagScaleFactor      = tr.getVar<double>("bTagSF_EventWeightSimple_Central");
             //puScaleFactor        = tr.getVar<double>("puWeightCorr");
             //prefiringScaleFactor = tr.getVar<double>("prefiringScaleFactor");
@@ -183,8 +180,8 @@ void HEM_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
         {
             {"passBaseline_0l",         passBaseline_0l},
             {"passBaseline_1l",         passBaseline_1l}, 
-            {"passBaseline_0l_HEMveto", passBaseline_0l && passElectronHEMVeto},
-            {"passBaseline_1l_HEMveto", passBaseline_1l && passElectronHEMVeto}, 
+            {"passBaseline_0l_HEMveto", passBaseline_0l_HEMveto},
+            {"passBaseline_1l_HEMveto", passBaseline_1l_HEMveto}, 
         };
 
         if (!inithisto) 

--- a/Analyzer/src/HEM_Analyzer.cc
+++ b/Analyzer/src/HEM_Analyzer.cc
@@ -106,39 +106,39 @@ void HEM_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
         if( maxevents != -1 && tr.getEvtNum() >= maxevents ) break;
         if( tr.getEvtNum() % 1000 == 0) printf( " Event %i\n", tr.getEvtNum() );
 
-        const auto& runtype               = tr.getVar<std::string>("runtype");     
-        const auto& RunNum                = tr.getVar<unsigned int>("RunNum");
-        const auto& Jets                  = tr.getVec<utility::LorentzVector>("Jets");
-        const auto& GoodLeptons           = tr.getVec<std::pair<std::string, utility::LorentzVector>>("GoodLeptons");
-        const auto& GoodJets_pt30         = tr.getVec<bool>("GoodJets_pt30");
-        const auto& GoodBJets_pt30        = tr.getVec<bool>("GoodBJets_pt30");
-        const auto& NGoodLeptons            = tr.getVar<int>("NGoodLeptons");
-        const auto& NGoodJets_pt30          = tr.getVar<int>("NGoodJets_pt30");
-        const auto& NGoodBJets_pt30         = tr.getVar<int>("NGoodBJets_pt30");
-        const auto& HT_trigger_pt30         = tr.getVar<double>("HT_trigger_pt30");
-        const auto& met                     = tr.getVar<float>("MET");
-        const auto& lvMET_cm_m              = tr.getVar<double>("lvMET_cm_m");
-        const auto& lvMET_cm_eta            = tr.getVar<double>("lvMET_cm_eta");
-        const auto& lvMET_cm_phi            = tr.getVar<double>("lvMET_cm_phi");
-        const auto& lvMET_cm_pt             = tr.getVar<double>("lvMET_cm_pt");
-        const auto& fwm2_top6               = tr.getVar<double>("fwm2_top6");
-        const auto& fwm3_top6               = tr.getVar<double>("fwm3_top6");
-        const auto& fwm4_top6               = tr.getVar<double>("fwm4_top6");
-        const auto& fwm5_top6               = tr.getVar<double>("fwm5_top6");
-        const auto& fwm6_top6               = tr.getVar<double>("fwm6_top6");
-        const auto& fwm7_top6               = tr.getVar<double>("fwm7_top6");
-        const auto& fwm8_top6               = tr.getVar<double>("fwm8_top6");
-        const auto& fwm9_top6               = tr.getVar<double>("fwm9_top6");
-        const auto& fwm10_top6              = tr.getVar<double>("fwm10_top6");
-        const auto& jmt_ev0_top6            = tr.getVar<double>("jmt_ev0_top6");
-        const auto& jmt_ev1_top6            = tr.getVar<double>("jmt_ev1_top6");
-        const auto& jmt_ev2_top6            = tr.getVar<double>("jmt_ev2_top6");
-        const auto& event_beta_z            = tr.getVar<double>("event_beta_z");
-        const auto& passMadHT               = tr.getVar<bool>("passMadHT");
-        const auto& passBaseline_0l         = tr.getVar<bool>("passBaseline0l_good");
-        const auto& passBaseline_1l         = tr.getVar<bool>("passBaseline1l_Good");
-        const auto& passBaseline_0l_HEMveto = tr.getVar<bool>("passBaseline0l_good_HEMveto");
-        const auto& passBaseline_1l_HEMveto = tr.getVar<bool>("passBaseline1l_Good_HEMveto");
+        const auto& runtype                   = tr.getVar<std::string>("runtype");     
+        const auto& RunNum                    = tr.getVar<unsigned int>("RunNum");
+        const auto& Jets                      = tr.getVec<utility::LorentzVector>("Jets");
+        const auto& GoodLeptons               = tr.getVec<std::pair<std::string, utility::LorentzVector>>("GoodLeptons");
+        const auto& GoodJets_pt30             = tr.getVec<bool>("GoodJets_pt30");
+        const auto& GoodBJets_pt30            = tr.getVec<bool>("GoodBJets_pt30");
+        const auto& NGoodLeptons              = tr.getVar<int>("NGoodLeptons");
+        const auto& NGoodJets_pt30            = tr.getVar<int>("NGoodJets_pt30");
+        const auto& NGoodBJets_pt30           = tr.getVar<int>("NGoodBJets_pt30");
+        const auto& HT_trigger_pt30           = tr.getVar<double>("HT_trigger_pt30");
+        const auto& met                       = tr.getVar<float>("MET");
+        const auto& lvMET_cm_m                = tr.getVar<double>("lvMET_cm_m");
+        const auto& lvMET_cm_eta              = tr.getVar<double>("lvMET_cm_eta");
+        const auto& lvMET_cm_phi              = tr.getVar<double>("lvMET_cm_phi");
+        const auto& lvMET_cm_pt               = tr.getVar<double>("lvMET_cm_pt");
+        const auto& fwm2_top6                 = tr.getVar<double>("fwm2_top6");
+        const auto& fwm3_top6                 = tr.getVar<double>("fwm3_top6");
+        const auto& fwm4_top6                 = tr.getVar<double>("fwm4_top6");
+        const auto& fwm5_top6                 = tr.getVar<double>("fwm5_top6");
+        const auto& fwm6_top6                 = tr.getVar<double>("fwm6_top6");
+        const auto& fwm7_top6                 = tr.getVar<double>("fwm7_top6");
+        const auto& fwm8_top6                 = tr.getVar<double>("fwm8_top6");
+        const auto& fwm9_top6                 = tr.getVar<double>("fwm9_top6");
+        const auto& fwm10_top6                = tr.getVar<double>("fwm10_top6");
+        const auto& jmt_ev0_top6              = tr.getVar<double>("jmt_ev0_top6");
+        const auto& jmt_ev1_top6              = tr.getVar<double>("jmt_ev1_top6");
+        const auto& jmt_ev2_top6              = tr.getVar<double>("jmt_ev2_top6");
+        const auto& event_beta_z              = tr.getVar<double>("event_beta_z");
+        const auto& passMadHT                 = tr.getVar<bool>("passMadHT");
+        const auto& passBaseline_0l           = tr.getVar<bool>("passBaseline0l_good");
+        const auto& passBaseline_1l           = tr.getVar<bool>("passBaseline1l_Good");
+        const auto& passBaseline_0l_noHEMveto = tr.getVar<bool>("passBaseline0l_good_noHEMveto");
+        const auto& passBaseline_1l_noHEMveto = tr.getVar<bool>("passBaseline1l_Good_noHEMveto");
 
         // -------------------
         // -- Define weight
@@ -155,22 +155,19 @@ void HEM_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
         if(runtype == "MC")
         {
             eventweight          = tr.getVar<float>("LumiXsec");
-            //bTagScaleFactor      = tr.getVar<double>("bTagSF_EventWeightSimple_Central");
-            //puScaleFactor        = tr.getVar<double>("puWeightCorr");
-            //prefiringScaleFactor = tr.getVar<double>("prefiringScaleFactor");
+            bTagScaleFactor      = tr.getVar<double>("bTagSF_EventWeightSimple_Central");
+            puScaleFactor        = tr.getVar<double>("puWeightCorr");
+            prefiringScaleFactor = tr.getVar<double>("prefiringScaleFactor");
 
             // Define lepton weight
-            //if(NGoodLeptons == 1)
-            //{
-            //    const auto& eleLepWeight = tr.getVar<double>("totGoodElectronSF");
-            //    const auto& muLepWeight  = tr.getVar<double>("totGoodMuonSF");
-            //    leptonScaleFactor = (GoodLeptons[0].first == "e") ? eleLepWeight : muLepWeight;
-            //}
+            if(NGoodLeptons == 1)
+            {
+                const auto& eleLepWeight = tr.getVar<double>("totGoodElectronSF");
+                const auto& muLepWeight  = tr.getVar<double>("totGoodMuonSF");
+                leptonScaleFactor = (GoodLeptons[0].first == "e") ? eleLepWeight : muLepWeight;
+            }
     
-            //htDerivedScaleFactor = tr.getVar<double>("htDerivedweight");
-            //weight *= eventweight*leptonScaleFactor*bTagScaleFactor*htDerivedScaleFactor*prefiringScaleFactor*puScaleFactor;
-
-            weight *= eventweight;
+            weight *= eventweight*leptonScaleFactor*bTagScaleFactor*prefiringScaleFactor*puScaleFactor;
         }
 
         // -------------------------------------------------
@@ -178,10 +175,10 @@ void HEM_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
         // -------------------------------------------------
         const std::map<std::string, bool>& cutmap
         {
-            {"passBaseline_0l",         passBaseline_0l},
-            {"passBaseline_1l",         passBaseline_1l}, 
-            {"passBaseline_0l_HEMveto", passBaseline_0l_HEMveto},
-            {"passBaseline_1l_HEMveto", passBaseline_1l_HEMveto}, 
+            {"passBaseline_0l",           passBaseline_0l},
+            {"passBaseline_1l",           passBaseline_1l}, 
+            {"passBaseline_0l_noHEMveto", passBaseline_0l_noHEMveto},
+            {"passBaseline_1l_noHEMveto", passBaseline_1l_noHEMveto}, 
         };
 
         if (!inithisto) 
@@ -210,11 +207,11 @@ void HEM_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
                     {
                         if (!GoodJets_pt30[goodJet]) { continue; }
 
-                        my_histos["h_jetPt_"          +cutVar.first]->Fill( Jets[goodJet].Pt(), weight               );
-                        my_2d_histos["h_jet_EtaVsPhi_"+cutVar.first]->Fill( Jets[goodJet].Eta(), Jets[goodJet].Phi() ); 
+                        my_histos["h_jetPt_"          +cutVar.first]->Fill( Jets[goodJet].Pt(), weight                       );
+                        my_2d_histos["h_jet_EtaVsPhi_"+cutVar.first]->Fill( Jets[goodJet].Eta(), Jets[goodJet].Phi(), weight ); 
 
                         if (GoodBJets_pt30[goodJet])
-                            my_2d_histos["h_bjet_EtaVsPhi_"+cutVar.first]->Fill( Jets[goodJet].Eta(), Jets[goodJet].Phi() ); 
+                            my_2d_histos["h_bjet_EtaVsPhi_"+cutVar.first]->Fill( Jets[goodJet].Eta(), Jets[goodJet].Phi(), weight ); 
 
 
                         if (Jets[goodJet].Pt() > jetPtMax) 
@@ -227,11 +224,11 @@ void HEM_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
                         {
                             if (GoodLeptons[goodLep].first == "e") 
                             {
-                                my_2d_histos["h_electron_EtaVsPhi_"+cutVar.first]->Fill(GoodLeptons[goodLep].second.Eta(), GoodLeptons[goodLep].second.Phi());
+                                my_2d_histos["h_electron_EtaVsPhi_"+cutVar.first]->Fill(GoodLeptons[goodLep].second.Eta(), GoodLeptons[goodLep].second.Phi(), weight);
                             } 
                             else 
                             {
-                                my_2d_histos["h_muon_EtaVsPhi_"+cutVar.first]->Fill(GoodLeptons[goodLep].second.Eta(), GoodLeptons[goodLep].second.Phi());
+                                my_2d_histos["h_muon_EtaVsPhi_"+cutVar.first]->Fill(GoodLeptons[goodLep].second.Eta(), GoodLeptons[goodLep].second.Phi(), weight);
                             }
                         }        
                     }          
@@ -272,10 +269,10 @@ void HEM_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
                         if (!GoodJets_pt30[goodJet]) { continue; }
 
                         my_histos["h_jetPt_HEM_"          +cutVar.first]->Fill( Jets[goodJet].Pt(), weight               );
-                        my_2d_histos["h_jet_EtaVsPhi_HEM_"+cutVar.first]->Fill( Jets[goodJet].Eta(), Jets[goodJet].Phi() ); 
+                        my_2d_histos["h_jet_EtaVsPhi_HEM_"+cutVar.first]->Fill( Jets[goodJet].Eta(), Jets[goodJet].Phi(), weight ); 
 
                         if (GoodBJets_pt30[goodJet])
-                            my_2d_histos["h_bjet_EtaVsPhi_HEM_"+cutVar.first]->Fill( Jets[goodJet].Eta(), Jets[goodJet].Phi() ); 
+                            my_2d_histos["h_bjet_EtaVsPhi_HEM_"+cutVar.first]->Fill( Jets[goodJet].Eta(), Jets[goodJet].Phi(), weight ); 
 
 
                         if (Jets[goodJet].Pt() > jetPtMax)
@@ -288,11 +285,11 @@ void HEM_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
                         {
                             if (GoodLeptons[goodLep].first == "e")
                             {
-                                my_2d_histos["h_electron_EtaVsPhi_HEM_"+cutVar.first]->Fill(GoodLeptons[goodLep].second.Eta(), GoodLeptons[goodLep].second.Phi());
+                                my_2d_histos["h_electron_EtaVsPhi_HEM_"+cutVar.first]->Fill(GoodLeptons[goodLep].second.Eta(), GoodLeptons[goodLep].second.Phi(), weight);
                             }
                             else
                             {
-                                my_2d_histos["h_muon_EtaVsPhi_HEM_"+cutVar.first]->Fill(GoodLeptons[goodLep].second.Eta(), GoodLeptons[goodLep].second.Phi());
+                                my_2d_histos["h_muon_EtaVsPhi_HEM_"+cutVar.first]->Fill(GoodLeptons[goodLep].second.Eta(), GoodLeptons[goodLep].second.Phi(), weight);
                             }
                         }
                     }

--- a/Analyzer/test/HEM_Plotter.py
+++ b/Analyzer/test/HEM_Plotter.py
@@ -86,7 +86,7 @@ def pretty_Histo(histo,magicFactor=1.0,magicFactor2=1.0):
 #   -- with/without HEM labels
 #   -- with 0l/1l labels
 # --------------------------------------
-def fill_Map(inRootDir, theMap, switch):
+def fill_Map(inRootDir, theMap):
 
     theMap["HEM"]   = {}
     theMap["NOHEM"] = {}
@@ -226,7 +226,7 @@ if __name__ == '__main__':
         os.makedirs(outpath)
 
     mapPFAhistos = {}
-    fill_Map(inRootDir, mapPFAhistos, args.tag)
+    fill_Map(inRootDir, mapPFAhistos)
 
     # -------------------------
     # Save the final histograms

--- a/Analyzer/test/HEM_Plotter.py
+++ b/Analyzer/test/HEM_Plotter.py
@@ -12,7 +12,16 @@ def do_Options(histo, histoName, theMap):
     is1D   = "TH1" in histo.ClassName()
     doLogY = False
 
-    for axis, options in theMap[histoName].iteritems():
+    optDict = None 
+    for key, value in theMap.items():
+        if key in histoName:
+            optDict = value
+            break
+
+    if optDict == None:
+        return False
+
+    for axis, options in optDict.items():
 
         # x-axis
         if axis == "X":
@@ -77,7 +86,7 @@ def pretty_Histo(histo,magicFactor=1.0,magicFactor2=1.0):
 #   -- with/without HEM labels
 #   -- with 0l/1l labels
 # --------------------------------------
-def fill_Map(inRootDir, theMap):
+def fill_Map(inRootDir, theMap, switch):
 
     theMap["HEM"]   = {}
     theMap["NOHEM"] = {}
@@ -86,7 +95,7 @@ def fill_Map(inRootDir, theMap):
 
         if ".root" not in histoFile: continue
         
-        histoFile = ROOT.TFile.Open(inRootDir + histoFile, "READ")
+        histoFile = ROOT.TFile.Open(inRootDir + "/" + histoFile, "READ")
         
         for hkey in histoFile.GetListOfKeys():
             if "TH" not in hkey.GetClassName(): continue
@@ -96,11 +105,14 @@ def fill_Map(inRootDir, theMap):
             keyName = ""
             if "HEM" in hkey.GetName(): 
                 keyName = "HEM"
-            else: 
+            elif "HEM" not in hkey.GetName(): 
                 keyName = "NOHEM"
+            else:
+                continue
 
             name  = hkey.GetName()
-            name  = name.replace("_HEM","")
+            name  = name.replace("_HEM","").replace("veto", "")
+
             histo = hkey.ReadObj()
             histo.SetDirectory(0)
             histo.Sumw2()
@@ -162,6 +174,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(usage)
     parser.add_argument("--inputDir", dest="inputDir", help="input directory",                   default="condor/hadd_2018_HEM_issue_0l_1l_18.04.2022/", type=str)
     parser.add_argument("--data",     dest="data",     help="JetHT, SingleElectron, SingleMuon", default="NULL", type=str)
+    parser.add_argument("--tag",      dest="tag",     help="Tag to put in folder name",          default="NULL", type=str)
     parser.add_argument("--ratio",    dest="ratio",    help="Draw ratio", action="store_true",   default=False)
     
     args = parser.parse_args()
@@ -193,9 +206,10 @@ if __name__ == '__main__':
             "h_jmt_ev1_top6"      : {  "Y" : {"logY" : True, },  "X" : {"rebin" : 30,  "title" : "JMT 1"                                               }  },
             "h_jmt_ev2_top6"      : {  "Y" : {"logY" : True, },  "X" : {"rebin" : 30,  "title" : "JMT 2"                                               }  },
             "h_event_beta_z"      : {  "Y" : {"logY" : False,},  "X" : {"rebin" : 50,  "title" : "#beta_{z}"                                           }  },
-            "h_jet_EtaVsPhi"      : {  "Y" : {"logY" : True, "rebin" : 80, "title" : "Jet #phi"},      "X" : {"rebin" : 360, "title" : "Jet #eta"      }  },
-            "h_electron_EtaVsPhi" : {  "Y" : {"logY" : True, "rebin" : 80, "title" : "Electron #phi"}, "X" : {"rebin" : 360, "title" : "Electron #eta" }  },
-            "h_muon_EtaVsPhi"     : {  "Y" : {"logY" : True, "rebin" : 80, "title" : "Muon #phi"},     "X" : {"rebin" : 360, "title" : "Muon #eta"     }  },
+            "h_jet_EtaVsPhi"      : {  "Y" : {"logY" : True, "rebin" : 12, "title" : "Jet #phi"},      "X" : {"rebin" : 12, "title" : "Jet #eta"      }  },
+            "h_bjet_EtaVsPhi"     : {  "Y" : {"logY" : True, "rebin" : 12, "title" : "b Jet #phi"},    "X" : {"rebin" : 12, "title" : "b Jet #eta"    }  },
+            "h_electron_EtaVsPhi" : {  "Y" : {"logY" : True, "rebin" : 12, "title" : "Electron #phi"}, "X" : {"rebin" : 12, "title" : "Electron #eta" }  },
+            "h_muon_EtaVsPhi"     : {  "Y" : {"logY" : True, "rebin" : 12, "title" : "Muon #phi"},     "X" : {"rebin" : 12, "title" : "Muon #eta"     }  },
     }
 
     # -----------------------------------
@@ -206,19 +220,19 @@ if __name__ == '__main__':
     YCANVAS = 2400
 
     inRootDir = args.inputDir
-    outpath   = "./2018UL_HEM_Study_0l_1l/%s/"%(args.data)
+    outpath   = "./2018UL_HEM_Study_0l_1l_%s/%s/"%(args.tag,args.data)
     
     if not os.path.exists(outpath): 
         os.makedirs(outpath)
 
     mapPFAhistos = {}
-    fill_Map(inRootDir, mapPFAhistos)
+    fill_Map(inRootDir, mapPFAhistos, args.tag)
 
     # -------------------------
     # Save the final histograms
     # -------------------------
     for name in mapPFAhistos.values()[0].keys():
-
+        
         if "0l" in name and "Single" in args.data: continue 
 
         if "1l" in name and "JetHT" in args.data: continue
@@ -255,16 +269,17 @@ if __name__ == '__main__':
             pretty_Histo(data1,0.875,0.8)
             pretty_Histo(data2,0.875,0.8)
 
-            theName = data1.GetName().replace("_HEM", "").rpartition("_")[0].rpartition("_")[0]
-            if theName in optionsMap:
-                do_Options(data1, theName, optionsMap)
-                do_Options(data2, theName, optionsMap)
+            theName = data1.GetName()
+            do_Options(data1, theName, optionsMap)
+            do_Options(data2, theName, optionsMap)
 
             data1.SetTitle("")
             data2.SetTitle("")
             data1.SetContour(255)
             data2.SetContour(255)
-            data1.Draw("COLZ TEXT E")
+
+            data1.Draw("COLZ")
+
             data1.SetTitle("post HEM")
             #add_CMSlogo(c1)
             c1.SaveAs("%s/%s_HEM.pdf"%(outpath,name))
@@ -280,7 +295,7 @@ if __name__ == '__main__':
             ROOT.gPad.SetLeftMargin(magicMargins_2D["L"])
             ROOT.gPad.SetRightMargin(magicMargins_2D["R"])
 
-            data2.Draw("COLZ TEXT E")
+            data2.Draw("COLZ")
             data2.SetTitle("pre HEM")
             #add_CMSlogo(c2)
             c2.SaveAs("%s/%s_NOHEM.pdf"%(outpath,name))
@@ -302,7 +317,7 @@ if __name__ == '__main__':
                 data2.Scale(1./data2.Integral())
                 data1.Divide(data2)
                 data1.GetZaxis().SetRangeUser(0.5,2.0)
-                data1.Draw("COLZ TEXT E")
+                data1.Draw("COLZ")
                 data1.SetTitle("HEM Ratio")
                 c1.SaveAs("%s/%s_ratio.pdf"%(outpath,name))
 
@@ -342,11 +357,10 @@ if __name__ == '__main__':
                 pretty_Histo(data2)
                 pretty_Histo(ratio,PadFactor)
 
-                theName = data1.GetName().replace("_HEM", "").rpartition("_")[0].rpartition("_")[0]
-                if theName in optionsMap:
-                    do_Options(data1, theName, optionsMap)
-                    do_Options(data2, theName, optionsMap)
-                    do_Options(ratio, theName, optionsMap)
+                theName = data1.GetName()
+                do_Options(data1, theName, optionsMap)
+                do_Options(data2, theName, optionsMap)
+                do_Options(ratio, theName, optionsMap)
 
                 data2.SetMarkerColor(38)
                 data2.SetLineColor(38)


### PR DESCRIPTION
Companion PR: https://github.com/StealthStop/Framework/pull/298

--add `Lumi_preHEM` and `Lumi_postHEM` to `Config.h`, defaulting to `-1.0` and being set accordingly when `runYear == "2018"`.
  * not necessarily for the user, but gets used by `PrepNtupleVars.h` to define `LumiXsec` properly
--miscellaneous small changes for HEM study