### PR TITLE
Miscellaneous Cleanup and Fixes

### DIFF
--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -45,9 +45,6 @@ private:
         const auto& DoubleDisCo_Model_1l_SYY          = tr.getVar<std::string>("DoubleDisCo_Model_1l_SYY"         );    
         const auto& DoubleDisCo_Cfg_NonIsoMuon_1l_SYY = tr.getVar<std::string>("DoubleDisCo_Cfg_NonIsoMuon_1l_SYY");
 
-        //const auto& DoubleDisCo_Cfg_2l    = tr.getVar<std::string>("DoubleDisCo_Cfg_2l"   ); 
-        //const auto& DoubleDisCo_Model_2l  = tr.getVar<std::string>("DoubleDisCo_Model_2l" );
-        //const auto& DoubleDisCo_Cfg_NonIsoMuon_2l = tr.getVar<std::string>("DoubleDisCo_Cfg_NonIsoMuon_2l");
         const auto& leptonFileName        = tr.getVar<std::string>("leptonFileName"       );
         const auto& bjetFileName          = tr.getVar<std::string>("bjetFileName"         );
         const auto& bjetCSVFileName       = tr.getVar<std::string>("bjetCSVFileName"      );
@@ -97,8 +94,6 @@ private:
             else if(module=="DoubleDisCo_1l_SYY")                    tr.emplaceModule<DeepEventShape>(DoubleDisCo_Cfg_1l_SYY, DoubleDisCo_Model_1l_SYY); 
             else if(module=="DoubleDisCo_NonIsoMuon_1l_SYY")         tr.emplaceModule<DeepEventShape>(DoubleDisCo_Cfg_NonIsoMuon_1l_SYY, DoubleDisCo_Model_1l_SYY);
 
-            //else if(module=="DoubleDisCo_2l")                        tr.emplaceModule<DeepEventShape>(DoubleDisCo_Cfg_2l, DoubleDisCo_Model_2l);
- 
             if(runtype == "MC")
             {
                 if     (module=="ScaleFactors")  tr.emplaceModule<ScaleFactors>(runYear, leptonFileName, meanFileName);
@@ -128,7 +123,6 @@ public:
         std::string DoubleDisCo_Cfg_1l_RPV, DoubleDisCo_Model_1l_RPV, DoubleDisCo_Cfg_NonIsoMuon_1l_RPV; 
         std::string DoubleDisCo_Cfg_0l_SYY, DoubleDisCo_Model_0l_SYY, DoubleDisCo_Cfg_NonIsoMuon_0l_SYY; 
         std::string DoubleDisCo_Cfg_1l_SYY, DoubleDisCo_Model_1l_SYY, DoubleDisCo_Cfg_NonIsoMuon_1l_SYY; 
-        //std::string DoubleDisCo_Cfg_2l, DoubleDisCo_Model_2l, DoubleDisCo_Cfg_NonIsoMuon_2l;      
         std::string leptonFileName, bjetFileName, bjetCSVFileName, meanFileName, TopTaggerCfg;
  
         double Lumi=0.0, Lumi_postHEM=-1.0, Lumi_preHEM=-1.0;
@@ -157,9 +151,6 @@ public:
             DoubleDisCo_Model_1l_SYY          = "keras_frozen_DoubleDisCo_Reg_1l_RPV_2016.pb";
             DoubleDisCo_Cfg_NonIsoMuon_1l_SYY = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_1l_RPV_2016.cfg";
 
-            //DoubleDisCo_Cfg_2l    = "Keras_Tensorflow_DoubleDisCo_Reg_2l_2016.cfg";
-            //DoubleDisCo_Model_2l  = "keras_frozen_DoubleDisCo_Reg_2l_2016.pb";
-            //DoubleDisCo_Cfg_NonIsoMuon_2l = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_2l_2016.cfg";
             leptonFileName        = "allInOne_leptonSF_UL.root";
             bjetFileName          = "allInOne_BTagEff_UL.root";
             bjetCSVFileName       = "wp_deepCSV_106XUL16preVFP_v2.csv";
@@ -190,9 +181,6 @@ public:
             DoubleDisCo_Model_1l_SYY          = "keras_frozen_DoubleDisCo_Reg_1l_RPV_2016.pb";
             DoubleDisCo_Cfg_NonIsoMuon_1l_SYY = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_1l_RPV_2016.cfg";
 
-            //DoubleDisCo_Cfg_2l    = "Keras_Tensorflow_DoubleDisCo_Reg_2l_2016.cfg";
-            //DoubleDisCo_Model_2l  = "keras_frozen_DoubleDisCo_Reg_2l_2016.pb";
-            //DoubleDisCo_Cfg_NonIsoMuon_2l = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_2l_2016.cfg";
             leptonFileName        = "allInOne_leptonSF_UL.root";
             bjetFileName          = "allInOne_BTagEff_UL.root";
             bjetCSVFileName       = "wp_deepCSV_106XUL16postVFP_v3.csv";
@@ -224,9 +212,6 @@ public:
             DoubleDisCo_Model_1l_SYY          = "keras_frozen_DoubleDisCo_Reg_1l_RPV_2016.pb";
             DoubleDisCo_Cfg_NonIsoMuon_1l_SYY = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_1l_RPV_2016.cfg";
 
-            //DoubleDisCo_Cfg_2l    = "Keras_Tensorflow_DoubleDisCo_Reg_2l_2016.cfg";
-            //DoubleDisCo_Model_2l  = "keras_frozen_DoubleDisCo_Reg_2l_2016.pb";
-            //DoubleDisCo_Cfg_NonIsoMuon_2l = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_2l_2016.cfg";
             leptonFileName        = "allInOne_leptonSF_UL.root";
             bjetFileName          = "allInOne_BTagEff_UL.root";
             bjetCSVFileName       = "wp_deepCSV_106XUL17_v3.csv";
@@ -258,9 +243,6 @@ public:
             DoubleDisCo_Model_1l_SYY          = "keras_frozen_DoubleDisCo_Reg_1l_RPV_2016.pb";
             DoubleDisCo_Cfg_NonIsoMuon_1l_SYY = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_1l_RPV_2016.cfg";
 
-            //DoubleDisCo_Cfg_2l    = "Keras_Tensorflow_DoubleDisCo_Reg_2l_2016.cfg";
-            //DoubleDisCo_Model_2l  = "keras_frozen_DoubleDisCo_Reg_2l_2016.pb";
-            //DoubleDisCo_Cfg_NonIsoMuon_2l = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_2l_2016.cfg";
             leptonFileName        = "allInOne_leptonSF_UL.root";
             bjetFileName          = "allInOne_BTagEff_UL.root";
             bjetCSVFileName       = "wp_deepCSV_106XUL18_v2.csv";
@@ -292,9 +274,6 @@ public:
             DoubleDisCo_Model_1l_SYY          = "keras_frozen_DoubleDisCo_Reg_1l_RPV_2016.pb";
             DoubleDisCo_Cfg_NonIsoMuon_1l_SYY = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_1l_RPV_2016.cfg";
 
-            //DoubleDisCo_Cfg_2l    = "Keras_Tensorflow_DoubleDisCo_Reg_2l_2016.cfg";
-            //DoubleDisCo_Model_2l  = "keras_frozen_DoubleDisCo_Reg_2l_2016.pb";
-            //DoubleDisCo_Cfg_NonIsoMuon_2l = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_2l_2016.cfg";
             leptonFileName        = "allInOne_leptonSF_UL.root";
             bjetFileName          = "allInOne_BTagEff_UL.root";
             bjetCSVFileName       = "wp_deepCSV_106XUL18_v2.csv";
@@ -328,9 +307,6 @@ public:
             DoubleDisCo_Model_1l_SYY          = "keras_frozen_DoubleDisCo_Reg_1l_RPV_2016.pb";
             DoubleDisCo_Cfg_NonIsoMuon_1l_SYY = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_1l_RPV_2016.cfg";
 
-            //DoubleDisCo_Cfg_2l    = "Keras_Tensorflow_DoubleDisCo_Reg_2l_2016.cfg";
-            //DoubleDisCo_Model_2l  = "keras_frozen_DoubleDisCo_Reg_2l_2016.pb";
-            //DoubleDisCo_Cfg_NonIsoMuon_2l = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_2l_2016.cfg";
             leptonFileName        = "allInOne_leptonSF_UL.root";
             bjetFileName          = "allInOne_BTagEff_UL.root";
             bjetCSVFileName       = "wp_deepCSV_106XUL18_v2.csv";
@@ -359,10 +335,6 @@ public:
         tr.registerDerivedVar("DoubleDisCo_Cfg_1l_SYY",            DoubleDisCo_Cfg_1l_SYY           );
         tr.registerDerivedVar("DoubleDisCo_Model_1l_SYY",          DoubleDisCo_Model_1l_SYY         );
         tr.registerDerivedVar("DoubleDisCo_Cfg_NonIsoMuon_1l_SYY", DoubleDisCo_Cfg_NonIsoMuon_1l_SYY);
-
-        //tr.registerDerivedVar("DoubleDisCo_Cfg_2l",    DoubleDisCo_Cfg_2l   );
-        //tr.registerDerivedVar("DoubleDisCo_Model_2l",  DoubleDisCo_Model_2l );
-        //tr.registerDerivedVar("DoubleDisCo_Cfg_NonIsoMuon_2l",    DoubleDisCo_Cfg_NonIsoMuon_2l   );
         tr.registerDerivedVar("leptonFileName",        leptonFileName       );        
         tr.registerDerivedVar("bjetFileName",          bjetFileName         );        
         tr.registerDerivedVar("bjetCSVFileName",       bjetCSVFileName      );        
@@ -479,12 +451,9 @@ public:
                 "CommonVariables",
                 "FatJetCombine",
                 "Baseline",
-                //"BTagCorrector",
-                //"ScaleFactors",        
+                "BTagCorrector",
+                "ScaleFactors",        
                 "MakeMVAVariables",
-                //"StopJets",
-                //"MakeStopHemispheres_OldSeed",
-                //"MakeStopHemispheres_TopSeed",
             };
             registerModules(tr, std::move(modulesList));
         }       
@@ -571,7 +540,13 @@ public:
         else if(analyzer=="AnalyzeXsec")
         {   
             const std::vector<std::string> modulesList = {
-                "PrepNTupleVars"
+                "PrepNTupleVars",
+                "Muon",
+                "Electron",
+                "Photon",
+                "Jet",
+                "BJet",
+                "CommonVariables",
             };
             registerModules(tr, std::move(modulesList));
         }

--- a/Analyzer/src/HEM_Analyzer.cc
+++ b/Analyzer/src/HEM_Analyzer.cc
@@ -154,7 +154,7 @@ void HEM_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool)
         
         if(runtype == "MC")
         {
-            eventweight          = tr.getVar<float>("LumiXsec");
+            eventweight          = tr.getVar<double>("LumiXsec");
             bTagScaleFactor      = tr.getVar<double>("bTagSF_EventWeightSimple_Central");
             puScaleFactor        = tr.getVar<double>("puWeightCorr");
             prefiringScaleFactor = tr.getVar<double>("prefiringScaleFactor");

--- a/Analyzer/test/condor/condorSubmit.py
+++ b/Analyzer/test/condor/condorSubmit.py
@@ -46,21 +46,23 @@ def main():
     testDir = environ["CMSSW_BASE"] + "/src/%s/test"%(repo) 
     
     # Prepare the list of files to transfer
-    mvaFileName2016 = getTopTaggerTrainingFile(environ["CMSSW_BASE"] + "/src/%s/test/TopTaggerCfg_2016.cfg" % repo)
-    mvaFileName2017 = getTopTaggerTrainingFile(environ["CMSSW_BASE"] + "/src/%s/test/TopTaggerCfg_2017.cfg" % repo)
-    mvaFileName2018 = getTopTaggerTrainingFile(environ["CMSSW_BASE"] + "/src/%s/test/TopTaggerCfg_2018.cfg" % repo)
+    mvaFileName2016preVFP  = getTopTaggerTrainingFile(environ["CMSSW_BASE"] + "/src/%s/test/TopTaggerCfg_2016preVFP.cfg" % repo)
+    mvaFileName2016postVFP = getTopTaggerTrainingFile(environ["CMSSW_BASE"] + "/src/%s/test/TopTaggerCfg_2016postVFP.cfg" % repo)
+    mvaFileName2017        = getTopTaggerTrainingFile(environ["CMSSW_BASE"] + "/src/%s/test/TopTaggerCfg_2017.cfg" % repo)
+    mvaFileName2018        = getTopTaggerTrainingFile(environ["CMSSW_BASE"] + "/src/%s/test/TopTaggerCfg_2018.cfg" % repo)
 
     filestoTransfer = [testDir + "/MyAnalysis", 
-                       testDir + "/%s" % (mvaFileName2016),
+                       testDir + "/%s" % (mvaFileName2016preVFP),
+                       testDir + "/%s" % (mvaFileName2016postVFP),
                        testDir + "/%s" % (mvaFileName2017),
                        testDir + "/%s" % (mvaFileName2018),
-                       testDir + "/TopTaggerCfg_2016.cfg",
+                       testDir + "/TopTaggerCfg_2016preVFP.cfg",
+                       testDir + "/TopTaggerCfg_2016postVFP.cfg",
                        testDir + "/TopTaggerCfg_2017.cfg",
                        testDir + "/TopTaggerCfg_2018.cfg",
                        srcDir  + "/TopTagger/TopTagger/test/libTopTagger.so",
                        testDir + "/sampleSets.cfg",
                        testDir + "/sampleCollections.cfg",
-                       testDir + "/Mass_Regression.cfg",
                        testDir + "/Keras_Tensorflow_DoubleDisCo_Reg_0l_RPV_2016.cfg",
                        testDir + "/Keras_Tensorflow_DoubleDisCo_Reg_1l_RPV_2016.cfg",
                        testDir + "/Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_0l_RPV_2016.cfg",
@@ -74,20 +76,12 @@ def main():
                        testDir + "/keras_frozen_DoubleDisCo_Reg_0l_SYY_2016.pb",
                        testDir + "/keras_frozen_DoubleDisCo_Reg_1l_SYY_2016.pb",
                        testDir + "/allInOne_BTagEff_UL.root",
-                       testDir + "/allInOne_SFMean.root",
+                       testDir + "/allInOne_SFMean_UL.root",
                        testDir + "/allInOne_leptonSF_UL.root",
-                       testDir + "/PileupHistograms_0121_69p2mb_pm4p6.root",
-                       testDir + "/pu_ratio.root",
-                       testDir + "/PileupHistograms_2018_69mb_pm5.root", 
-                       testDir + "/CSVv2_Moriond17_B_H.csv",
                        testDir + "/wp_deepCSV_106XUL16postVFP_v3.csv",
                        testDir + "/wp_deepCSV_106XUL16preVFP_v2.csv",
                        testDir + "/wp_deepCSV_106XUL17_v3.csv",
                        testDir + "/wp_deepCSV_106XUL18_v2.csv",
-                       testDir + "/DeepCSV_102XSF_WP_V1.csv",
-                       testDir + "/DeepCSV_2016LegacySF_WP_V1.csv",
-                       testDir + "/DeepCSV_94XSF_WP_V4_B_F.csv",
-                       testDir + "/L1prefiring_jetpt_2017BtoF.root",
                        ]
     
     print "--------------Files to Transfer-----------------"
@@ -172,8 +166,9 @@ def main():
         makeExeAndFriendsTarball(filestoTransfer, "exestuff", options.outPath)
         system("tar --exclude-caches-all --exclude-vcs -zcf %s/${CMSSW_VERSION}.tar.gz -C ${CMSSW_BASE}/.. ${CMSSW_VERSION} --exclude=src --exclude=tmp" % options.outPath)
         
+    system('mkdir -p %s/log-files' % options.outPath)
+
     if not options.noSubmit: 
-        system('mkdir -p %s/log-files' % options.outPath)
         system("echo 'condor_submit condor_submit.txt'")
         system('condor_submit condor_submit.txt')
     else:


### PR DESCRIPTION
--smartly download SF ROOT files based on whether they exist locally and/or their checksum does not match with corresponding file in EOS---removing need for manual user intervention with removing files to re-download
--keep module list for `AnalyzeXsec` and `HEM_Analyzer` up-to-date and working
--make sure to ship 2016preVPF and 2016postVPF top tagger cfg with condor jobs now
--remove shipping of deprecated ROOT/CSV files
--ship UL version of SF mean ROOT file