### PR TITLE
Anticipate ResolvedOnly TopTagger Config

### DIFF
--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -474,7 +474,7 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
-                "RunTopTagger",
+                "RunTopTagger_ResolvedOnly",
                 "CommonVariables",
                 "FatJetCombine",
                 "Baseline",

--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -447,7 +447,7 @@ public:
             };
             registerModules(tr, std::move(modulesList));
         }       
-        else if(analyzer=="TopTaggerSF_Analyzer" || analyzer=="ResolvedTopTagger_Analyzer")
+        else if(analyzer=="TopTaggerSF_Analyzer")
         {
             const std::vector<std::string> modulesList = {
                 "PrepNTupleVars",
@@ -456,7 +456,25 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
-                "RunTopTagger_ResolvedOnly",
+                "RunTopTagger",
+                "CommonVariables",
+                "FatJetCombine",
+                "Baseline",
+                "BTagCorrector",
+                "ScaleFactors"
+            };
+            registerModules(tr, std::move(modulesList));
+        }
+        else if(analyzer=="ResolvedTopTagger_Analyzer")
+        {
+            const std::vector<std::string> modulesList = {
+                "PrepNTupleVars",
+                "Muon",
+                "Electron",
+                "Photon",
+                "Jet",
+                "BJet",
+                "RunTopTagger",
                 "CommonVariables",
                 "FatJetCombine",
                 "Baseline",

--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -55,12 +55,15 @@ private:
         const auto& filetag                   = tr.getVar<std::string>("filetag"                     );
         const auto& meanFileName              = tr.getVar<std::string>("meanFileName"                );
         const auto& TopTaggerCfg              = tr.getVar<std::string>("TopTaggerCfg"                );
+        const auto& TopTaggerCfg_ResolvedOnly = tr.getVar<std::string>("TopTaggerCfg_ResolvedOnly"   );
+
  
         for(const auto& module : modules)
         {
             if     (module=="PartialUnBlinding")                     tr.emplaceModule<PartialUnBlinding>();
             else if(module=="PrepNTupleVars")                        tr.emplaceModule<PrepNTupleVars>();
             else if(module=="RunTopTagger")                          tr.emplaceModule<RunTopTagger>(TopTaggerCfg);
+            else if(module=="RunTopTagger_ResolvedOnly")             tr.emplaceModule<RunTopTagger>(TopTaggerCfg_ResolvedOnly);
             else if(module=="Muon")                                  tr.emplaceModule<Muon>();
             else if(module=="Electron")                              tr.emplaceModule<Electron>();
             else if(module=="Photon")                                tr.emplaceModule<Photon>();
@@ -128,7 +131,7 @@ public:
         std::string DoubleDisCo_Cfg_1l_RPV, DoubleDisCo_Model_1l_RPV, DoubleDisCo_Cfg_NonIsoMuon_1l_RPV; 
         std::string DoubleDisCo_Cfg_0l_SYY, DoubleDisCo_Model_0l_SYY, DoubleDisCo_Cfg_NonIsoMuon_0l_SYY; 
         std::string DoubleDisCo_Cfg_1l_SYY, DoubleDisCo_Model_1l_SYY, DoubleDisCo_Cfg_NonIsoMuon_1l_SYY; 
-        std::string leptonFileName, hadronicFileName, bjetFileName, bjetCSVFileName, bjetCSVFileNameReshape, meanFileName, TopTaggerCfg;
+        std::string leptonFileName, hadronicFileName, bjetFileName, bjetCSVFileName, bjetCSVFileNameReshape, meanFileName, TopTaggerCfg, TopTaggerCfg_ResolvedOnly;
  
         double Lumi=0.0, Lumi_postHEM=-1.0, Lumi_preHEM=-1.0;
         double deepCSV_WP_loose=0.0, deepCSV_WP_medium=0.0, deepCSV_WP_tight=0.0;
@@ -164,6 +167,8 @@ public:
             meanFileName                      = "allInOne_SFMean_UL.root";
             blind                             = true;
             TopTaggerCfg                      = "TopTaggerCfg_2016preVFP.cfg";
+            TopTaggerCfg_ResolvedOnly         = "TopTaggerCfg_ResolvedOnly_2016preVFP.cfg";
+
         }
 
         else if(filetag.find("2016postVFP") != std::string::npos)
@@ -195,6 +200,8 @@ public:
             meanFileName                      = "allInOne_SFMean_UL.root";
             blind                             = true;
             TopTaggerCfg                      = "TopTaggerCfg_2016postVFP.cfg";
+            TopTaggerCfg_ResolvedOnly         = "TopTaggerCfg_ResolvedOnly_2016postVFP.cfg";
+
         }
         else if(filetag.find("2017") != std::string::npos)
         { 
@@ -225,6 +232,8 @@ public:
             meanFileName                      = "allInOne_SFMean_UL.root";
             blind                             = true;
             TopTaggerCfg                      = "TopTaggerCfg_2017.cfg";
+            TopTaggerCfg_ResolvedOnly         = "TopTaggerCfg_ResolvedOnly_2017.cfg";
+
         }
         else if(filetag.find("2018") != std::string::npos) 
         {
@@ -257,6 +266,8 @@ public:
             meanFileName                      = "allInOne_SFMean_UL.root";
             blind                             = true;
             TopTaggerCfg                      = "TopTaggerCfg_2018.cfg";
+            TopTaggerCfg_ResolvedOnly         = "TopTaggerCfg_ResolvedOnly_2018.cfg";
+
         }
 
         tr.registerDerivedVar("runYear",                           runYear                          );
@@ -288,6 +299,7 @@ public:
         tr.registerDerivedVar("etaCut",                            2.4                              ); 
         tr.registerDerivedVar("blind",                             blind                            );
         tr.registerDerivedVar("TopTaggerCfg",                      TopTaggerCfg                     );
+        tr.registerDerivedVar("TopTaggerCfg_ResolvedOnly",         TopTaggerCfg_ResolvedOnly        );
 
         // Register Modules that are needed for each Analyzer
         if(analyzer=="MakeNJetDists") // for legacy 1l
@@ -435,6 +447,24 @@ public:
             };
             registerModules(tr, std::move(modulesList));
         }       
+        else if(analyzer=="TopTaggerSF_Analyzer")
+        {
+            const std::vector<std::string> modulesList = {
+                "PrepNTupleVars",
+                "Muon",
+                "Electron",
+                "Photon",
+                "Jet",
+                "BJet",
+                "RunTopTagger_ResolvedOnly",
+                "CommonVariables",
+                "FatJetCombine",
+                "Baseline",
+                "BTagCorrector",
+                "ScaleFactors"
+            };
+            registerModules(tr, std::move(modulesList));
+        }
         else if(analyzer=="Semra_Analyzer" || analyzer=="WholeTopTagger_Analyzer" || analyzer=="ResolvedTopTagger_Analyzer")
         {   
             const std::vector<std::string> modulesList = {
@@ -450,20 +480,11 @@ public:
                 "Baseline",
                 "BTagCorrector",
                 "ScaleFactors",
-                //"MakeMVAVariables_0l",
-                //"MakeMVAVariables_1l",
-                //"MakeMVAVariables_2l",
-                "MakeMVAVariables_NonIsoMuon_0l",
-                "MakeMVAVariables_NonIsoMuon_1l",
                 "StopJets",
                 "MakeStopHemispheres_OldSeed",
                 "MakeStopHemispheres_OldSeed_NonIsoMuon",
                 "MakeStopHemispheres_TopSeed",
                 "StopGenMatch",
-                //"DoubleDisCo_0l_RPV",
-                //"DoubleDisCo_1l_RPV",
-                //"DoubleDisCo_NonIsoMuon_0l_RPV",
-                //"DoubleDisCo_NonIsoMuon_1l_RPV",
             };
             registerModules(tr, std::move(modulesList));
         } 
@@ -481,7 +502,6 @@ public:
                 "FatJetCombine",
                 "Baseline",
                 "MakeMVAVariables_0l",
-                //"MakeMVAVariables_1l",
                 "ISRJets",
                 "StopJets",
                 "MakeStopHemispheres_All",

--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -447,7 +447,7 @@ public:
             };
             registerModules(tr, std::move(modulesList));
         }       
-        else if(analyzer=="TopTaggerSF_Analyzer")
+        else if(analyzer=="TopTaggerSF_Analyzer" || analyzer=="ResolvedTopTagger_Analyzer")
         {
             const std::vector<std::string> modulesList = {
                 "PrepNTupleVars",
@@ -465,7 +465,7 @@ public:
             };
             registerModules(tr, std::move(modulesList));
         }
-        else if(analyzer=="Semra_Analyzer" || analyzer=="WholeTopTagger_Analyzer" || analyzer=="ResolvedTopTagger_Analyzer")
+        else if(analyzer=="Semra_Analyzer" || analyzer=="WholeTopTagger_Analyzer")
         {   
             const std::vector<std::string> modulesList = {
                 "PrepNTupleVars",

--- a/Analyzer/src/ResolvedTopTagger_Analyzer.cc
+++ b/Analyzer/src/ResolvedTopTagger_Analyzer.cc
@@ -77,7 +77,7 @@ void ResolvedTopTagger_Analyzer::Loop(NTupleReader& tr, double, int maxevents, b
         {
             // Define Lumi weight
             const auto& Weight = tr.getVar<float>("Weight");
-            const auto& lumi   = tr.getVar<double>("Lumi");
+            const auto& lumi   = tr.getVar<double>("FinalLumi");
             eventweight        = lumi*Weight;
 
             bTagScaleFactor      = tr.getVar<double>("bTagSF_EventWeightSimple_Central");

--- a/Analyzer/src/WholeTopTagger_Analyzer.cc
+++ b/Analyzer/src/WholeTopTagger_Analyzer.cc
@@ -99,7 +99,6 @@ void WholeTopTagger_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool
 
         // General variables
         const auto& runtype            = tr.getVar<std::string>("runtype");     
-        const auto& Jets               = tr.getVec<TLorentzVector>("Jets");
         // Top variables
         const auto& ntops              = tr.getVar<int>("ntops");
         const auto& ntops_3jet         = tr.getVar<int>("ntops_3jet"); // resolved 
@@ -152,12 +151,14 @@ void WholeTopTagger_Analyzer::Loop(NTupleReader& tr, double, int maxevents, bool
         if(runtype == "MC")
         {
             // Define Lumi weight
-            const auto& lumi     = tr.getVar<double>("Lumi");
+            const auto& lumi     = tr.getVar<double>("FinalLumi");
             const auto& Weight   = tr.getVar<double>("Weight");
             eventweight          = lumi*Weight;
             puScaleFactor        = tr.getVar<double>("puWeightCorr");
-        
-            weight *= eventweight * puScaleFactor;
+            prefiringScaleFactor = tr.getVar<double>("prefiringScaleFactor"            );
+            bTagScaleFactor      = tr.getVar<double>("bTagSF_EventWeightSimple_Central");
+
+            weight *= eventweight * puScaleFactor * prefiringScaleFactor * bTagScaleFactor;
         }
 
         // -------------------------------------------------


### PR DESCRIPTION
Handle a resolved only top tagger config and use when the module name suggests.
Some additional cleanup.