### PR TITLE
Rename FatJetCombine as JetAK8 and Cleanup

### DIFF
--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -23,7 +23,6 @@
 #include "Framework/Framework/include/MakeStopHemispheres.h"
 #include "Framework/Framework/include/StopJets.h"
 #include "Framework/Framework/include/ISRJets.h"
-#include "Framework/Framework/include/JetAK8.h"
 
 class Config
 {
@@ -84,7 +83,6 @@ private:
             else if(module=="Baseline")                              tr.emplaceModule<Baseline>();
             else if(module=="StopGenMatch")                          tr.emplaceModule<StopGenMatch>();
             else if(module=="MegaJetCombine")                        tr.emplaceModule<MegaJetCombine>();
-            else if(module=="JetAK8")                                tr.emplaceModule<JetAK8>();
             else if(module=="TrainingNTupleVars")                    tr.emplaceModule<TrainingNTupleVars>();
             else if(module=="MakeStopHemispheres_All")               tr.emplaceModule<MakeStopHemispheres>("Jets",     "AllJets",                 "NJets",                    "_All",                "", Hemisphere::InvMassSeed);
             else if(module=="MakeStopHemispheres_OldSeed")           tr.emplaceModule<MakeStopHemispheres>("Jets",     "GoodJets_pt20",           "NGoodJets_pt20",           "_OldSeed",            "", Hemisphere::InvMassSeed);
@@ -356,7 +354,6 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
-                "JetAK8",
                 "RunTopTagger",
                 "CommonVariables",
                 "Baseline",
@@ -384,7 +381,6 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
-                "JetAK8",
                 "RunTopTagger",
                 "CommonVariables",
                 "Baseline",
@@ -422,7 +418,6 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
-                "JetAK8",
                 "RunTopTagger",
                 "CommonVariables",
                 "Baseline",
@@ -441,7 +436,6 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
-                "JetAK8",
                 "RunTopTagger",
                 "CommonVariables",
                 "Baseline",
@@ -476,7 +470,6 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
-                "JetAK8",
                 "RunTopTagger",
                 "CommonVariables",
                 "Baseline",
@@ -500,7 +493,6 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
-                "JetAK8",
                 "RunTopTagger",
                 "CommonVariables",
                 "Baseline",
@@ -540,7 +532,6 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
-                "JetAK8",
                 "RunTopTagger",
                 "CommonVariables",
                 "Baseline",

--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -70,6 +70,7 @@ private:
             else if(module=="Electron")                              tr.emplaceModule<Electron>();
             else if(module=="Photon")                                tr.emplaceModule<Photon>();
             else if(module=="Jet")                                   tr.emplaceModule<Jet>();
+            else if(module=="JetAK8")                                tr.emplaceModule<JetAK8>();
             else if(module=="BJet")                                  tr.emplaceModule<BJet>();
             else if(module=="CommonVariables")                       tr.emplaceModule<CommonVariables>();
             else if(module=="MakeMVAVariables")                      tr.emplaceModule<MakeMVAVariables>(false, "", "GoodJets_pt30",        false, true, 7, 2, "");

--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -23,7 +23,7 @@
 #include "Framework/Framework/include/MakeStopHemispheres.h"
 #include "Framework/Framework/include/StopJets.h"
 #include "Framework/Framework/include/ISRJets.h"
-#include "Framework/Framework/include/FatJetCombine.h"
+#include "Framework/Framework/include/JetAK8.h"
 
 class Config
 {
@@ -84,7 +84,7 @@ private:
             else if(module=="Baseline")                              tr.emplaceModule<Baseline>();
             else if(module=="StopGenMatch")                          tr.emplaceModule<StopGenMatch>();
             else if(module=="MegaJetCombine")                        tr.emplaceModule<MegaJetCombine>();
-            else if(module=="FatJetCombine")                         tr.emplaceModule<FatJetCombine>();
+            else if(module=="JetAK8")                                tr.emplaceModule<JetAK8>();
             else if(module=="TrainingNTupleVars")                    tr.emplaceModule<TrainingNTupleVars>();
             else if(module=="MakeStopHemispheres_All")               tr.emplaceModule<MakeStopHemispheres>("Jets",     "AllJets",                 "NJets",                    "_All",                "", Hemisphere::InvMassSeed);
             else if(module=="MakeStopHemispheres_OldSeed")           tr.emplaceModule<MakeStopHemispheres>("Jets",     "GoodJets_pt20",           "NGoodJets_pt20",           "_OldSeed",            "", Hemisphere::InvMassSeed);
@@ -356,9 +356,9 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
+                "JetAK8",
                 "RunTopTagger",
                 "CommonVariables",
-                "FatJetCombine",
                 "Baseline",
                 "MakeMVAVariables",
                 "DeepEventShape",
@@ -384,10 +384,10 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
+                "JetAK8",
                 "RunTopTagger",
                 "CommonVariables",
                 "Baseline",
-                "FatJetCombine",
                 "MakeMVAVariables",
                 "StopJets",
                 "MakeStopHemispheres_OldSeed",
@@ -422,9 +422,9 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
+                "JetAK8",
                 "RunTopTagger",
                 "CommonVariables",
-                "FatJetCombine",
                 "Baseline",
                 "BTagCorrector",
                 "ScaleFactors",        
@@ -441,9 +441,9 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
+                "JetAK8",
                 "RunTopTagger",
                 "CommonVariables",
-                "FatJetCombine",
                 "Baseline",
                 "BTagCorrector",
                 "ScaleFactors"
@@ -461,7 +461,6 @@ public:
                 "BJet",
                 "RunTopTagger_ResolvedOnly",
                 "CommonVariables",
-                "FatJetCombine",
                 "Baseline",
                 "BTagCorrector",
                 "ScaleFactors"
@@ -477,9 +476,9 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
+                "JetAK8",
                 "RunTopTagger",
                 "CommonVariables",
-                "FatJetCombine",
                 "Baseline",
                 "BTagCorrector",
                 "ScaleFactors",
@@ -501,9 +500,9 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
+                "JetAK8",
                 "RunTopTagger",
                 "CommonVariables",
-                "FatJetCombine",
                 "Baseline",
                 "MakeMVAVariables_0l",
                 "ISRJets",
@@ -541,9 +540,9 @@ public:
                 "Photon",
                 "Jet",
                 "BJet",
+                "JetAK8",
                 "RunTopTagger",
                 "CommonVariables",
-                "FatJetCombine",
                 "Baseline",
                 "BTagCorrector",
                 "ScaleFactors",

--- a/Analyzer/include/MakeNJetDists.h
+++ b/Analyzer/include/MakeNJetDists.h
@@ -13,7 +13,7 @@
 #include "Framework/Framework/include/Jet.h"
 #include "Framework/Framework/include/BJet.h"
 #include "Framework/Framework/include/CommonVariables.h"
-#include "Framework/Framework/include/FatJetCombine.h"
+#include "Framework/Framework/include/JetAK8.h"
 #include "Framework/Framework/include/Baseline.h"
 #include "Framework/Framework/include/MakeMVAVariables.h"
 #include "Framework/Framework/include/DeepEventShape.h"
@@ -189,6 +189,7 @@ public:
             BJet                bjet(myVarSuffix);
             Muon                muon(myVarSuffix);
             Photon              photon(myVarSuffix);
+            JetAK8              jetAK8(myVarSuffix);
             Baseline            baseline(myVarSuffix);
             Electron            electron(myVarSuffix);
             ScaleFactors        scaleFactors( runYear, leptonFileName, meanFileName, myVarSuffix);
@@ -197,7 +198,6 @@ public:
             DeepEventShape      deepEventShape(DeepESMCfg, ModelFile, "Info", true, myVarSuffix);
             CommonVariables     commonVariables(myVarSuffix);
             MakeMVAVariables    makeMVAVariables(false, myVarSuffix);
-            FatJetCombine       fatJetCombine(myVarSuffix);
             bTagCorrector.SetVarNames("GenParticles_PdgId", "Jets"+myVarSuffix, "GoodJets_pt30"+myVarSuffix, "Jets"+myVarSuffix+"_bJetTagDeepCSVtotb", "Jets"+myVarSuffix+"_partonFlavor", myVarSuffix);
   
             // Remember, order matters here !
@@ -209,7 +209,7 @@ public:
             tr.registerFunction(bjet);
             tr.registerFunction(topTagger);
             tr.registerFunction(commonVariables);
-            tr.registerFunction(fatJetCombine);
+            tr.registerFunction(jetAK8);
             tr.registerFunction(baseline);
             tr.registerFunction(makeMVAVariables);
             tr.registerFunction(deepEventShape);

--- a/Analyzer/src/AnalyzeDoubleDisCo.cc
+++ b/Analyzer/src/AnalyzeDoubleDisCo.cc
@@ -10,7 +10,7 @@
 #include "Framework/Framework/include/BJet.h"
 #include "Framework/Framework/include/CommonVariables.h"
 #include "Framework/Framework/include/RunTopTagger.h"
-#include "Framework/Framework/include/FatJetCombine.h"
+#include "Framework/Framework/include/JetAK8.h"
 #include "Framework/Framework/include/MakeMVAVariables.h"
 #include "Framework/Framework/include/Baseline.h"
 #include "Framework/Framework/include/BTagCorrector.h"
@@ -340,12 +340,12 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
         BJet                bjet(myVarSuffix);
         Muon                muon(myVarSuffix);
         Photon              photon(myVarSuffix);
+        JetAK8              jetAK8(myVarSuffix);
         Baseline            baseline(myVarSuffix);
         Electron            electron(myVarSuffix);
         StopJets            stopJets(myVarSuffix);
         RunTopTagger        topTagger(TopTaggerCfg, myVarSuffix);
         StopGenMatch        stopGenMatch(myVarSuffix);
-        FatJetCombine       fatJetCombine(myVarSuffix);
         DeepEventShape      neuralNetwork0L(DoubleDisCo_Cfg_0l_RPV, DoubleDisCo_Model_0l_RPV, "Info", true, myVarSuffix);
         DeepEventShape      neuralNetwork0L_NonIsoMuon(DoubleDisCo_Cfg_NonIsoMuon_0l_RPV, DoubleDisCo_Model_0l_RPV, "Info", true, myVarSuffix);
         DeepEventShape      neuralNetwork1L(DoubleDisCo_Cfg_1l_RPV, DoubleDisCo_Model_1l_RPV, "Info", true, myVarSuffix); 
@@ -374,7 +374,7 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
         tr.registerFunction(topTagger);
         tr.registerFunction(commonVariables);
         tr.registerFunction(baseline);
-        tr.registerFunction(fatJetCombine);
+        tr.registerFunction(jetAK8);
         tr.registerFunction(makeMVAVariables0L_NonIsoMuon);
         tr.registerFunction(makeMVAVariables1L_NonIsoMuon);
         tr.registerFunction(makeMVAVariables2L_NonIsoMuon);

--- a/Analyzer/src/AnalyzeDoubleDisCo.cc
+++ b/Analyzer/src/AnalyzeDoubleDisCo.cc
@@ -10,7 +10,6 @@
 #include "Framework/Framework/include/BJet.h"
 #include "Framework/Framework/include/CommonVariables.h"
 #include "Framework/Framework/include/RunTopTagger.h"
-#include "Framework/Framework/include/JetAK8.h"
 #include "Framework/Framework/include/MakeMVAVariables.h"
 #include "Framework/Framework/include/Baseline.h"
 #include "Framework/Framework/include/BTagCorrector.h"
@@ -340,7 +339,6 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
         BJet                bjet(myVarSuffix);
         Muon                muon(myVarSuffix);
         Photon              photon(myVarSuffix);
-        JetAK8              jetAK8(myVarSuffix);
         Baseline            baseline(myVarSuffix);
         Electron            electron(myVarSuffix);
         StopJets            stopJets(myVarSuffix);
@@ -374,7 +372,6 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
         tr.registerFunction(topTagger);
         tr.registerFunction(commonVariables);
         tr.registerFunction(baseline);
-        tr.registerFunction(jetAK8);
         tr.registerFunction(makeMVAVariables0L_NonIsoMuon);
         tr.registerFunction(makeMVAVariables1L_NonIsoMuon);
         tr.registerFunction(makeMVAVariables2L_NonIsoMuon);

--- a/Analyzer/src/MakeNNVariables.cc
+++ b/Analyzer/src/MakeNNVariables.cc
@@ -11,7 +11,6 @@
 #include "Framework/Framework/include/BJet.h"
 #include "Framework/Framework/include/CommonVariables.h"
 #include "Framework/Framework/include/RunTopTagger.h"
-#include "Framework/Framework/include/JetAK8.h"
 #include "Framework/Framework/include/MakeMVAVariables.h"
 #include "Framework/Framework/include/Baseline.h"
 #include "Framework/Framework/include/BTagCorrector.h"
@@ -41,7 +40,6 @@ void MakeNNVariables::Loop(NTupleReader& tr, double, int maxevents, bool)
         BJet                bjet(myVarSuffix);
         Muon                muon(myVarSuffix);
         Photon              photon(myVarSuffix);
-        JetAK8              jetAK8(myVarSuffix);
         Baseline            baseline(myVarSuffix);
         Electron            electron(myVarSuffix);
         StopJets            stopJets(myVarSuffix);
@@ -62,7 +60,6 @@ void MakeNNVariables::Loop(NTupleReader& tr, double, int maxevents, bool)
         tr.registerFunction(topTagger);
         tr.registerFunction(commonVariables);
         tr.registerFunction(baseline);
-        tr.registerFunction(jetAK8);
         tr.registerFunction(makeMVAVariables);
         tr.registerFunction(stopJets);
         tr.registerFunction(stopHemispheres_OldSeed);

--- a/Analyzer/src/MakeNNVariables.cc
+++ b/Analyzer/src/MakeNNVariables.cc
@@ -11,7 +11,7 @@
 #include "Framework/Framework/include/BJet.h"
 #include "Framework/Framework/include/CommonVariables.h"
 #include "Framework/Framework/include/RunTopTagger.h"
-#include "Framework/Framework/include/FatJetCombine.h"
+#include "Framework/Framework/include/JetAK8.h"
 #include "Framework/Framework/include/MakeMVAVariables.h"
 #include "Framework/Framework/include/Baseline.h"
 #include "Framework/Framework/include/BTagCorrector.h"
@@ -41,12 +41,12 @@ void MakeNNVariables::Loop(NTupleReader& tr, double, int maxevents, bool)
         BJet                bjet(myVarSuffix);
         Muon                muon(myVarSuffix);
         Photon              photon(myVarSuffix);
+        JetAK8              jetAK8(myVarSuffix);
         Baseline            baseline(myVarSuffix);
         Electron            electron(myVarSuffix);
         StopJets            stopJets(myVarSuffix);
         RunTopTagger        topTagger(TopTaggerCfg, myVarSuffix);
         StopGenMatch        stopGenMatch(myVarSuffix);
-        FatJetCombine       fatJetCombine(myVarSuffix);
         CommonVariables     commonVariables(myVarSuffix);
         MakeMVAVariables    makeMVAVariables(false, myVarSuffix, "GoodJets_pt30", false, true, 7, 2, "");
         MakeStopHemispheres stopHemispheres_OldSeed("Jets",     "GoodJets_pt20", "NGoodJets_pt20", "_OldSeed", myVarSuffix, Hemisphere::InvMassSeed);
@@ -62,7 +62,7 @@ void MakeNNVariables::Loop(NTupleReader& tr, double, int maxevents, bool)
         tr.registerFunction(topTagger);
         tr.registerFunction(commonVariables);
         tr.registerFunction(baseline);
-        tr.registerFunction(fatJetCombine);
+        tr.registerFunction(jetAK8);
         tr.registerFunction(makeMVAVariables);
         tr.registerFunction(stopJets);
         tr.registerFunction(stopHemispheres_OldSeed);


### PR DESCRIPTION
--see companion PR in https://github.com/StealthStop/Framework/pull/332
--as the only place `GoodJetsAK8` was used was in `MakeMVAVariables.h` and that will be no more with the above PR, take the opportunity to exclude `JetAK8.h` from any analyzer for time savings.