### PR TITLE
Enhancements to hadder.py

### DIFF
--- a/Analyzer/test/condor/hadder.py
+++ b/Analyzer/test/condor/hadder.py
@@ -1,16 +1,19 @@
-import sys, os
-from os import system, environ
+import os
 import subprocess
 
 from samples import SampleCollection
 import argparse
-from glob import glob
-import datetime
+import glob
 import shutil
 import ROOT
 
 def red(string):
      CRED = "\033[91m"
+     CEND = "\033[0m"
+     return CRED + str(string) + CEND
+
+def cyan(string):
+     CRED = "\033[96m"
      CEND = "\033[0m"
      return CRED + str(string) + CEND
 
@@ -48,22 +51,27 @@ def checkNumEvents(nEvents, rootFile, sampleCollection, log):
 
     return log
 
-def listFiles(inPath, query):
+def listFiles(inPath, query, eosCompatible=True):
 
-    stub = query.split("/MyAnalysis")[0]
+    files = None
+    if eosCompatible:
+        stub = query.split("/MyAnalysis")[0]
+        commandList = ["eos", "root://cmseos.fnal.gov", "ls", query]
 
-    proc = subprocess.Popen(["eos", "root://cmseos.fnal.gov", "ls", query], stdout=subprocess.PIPE)
-    payload = proc.stdout.readlines()
-    files   = ["/eos/uscms" + stub + "/" + file.rstrip() for file in payload]
+        proc = subprocess.Popen(commandList, stdout=subprocess.PIPE)
+        payload = proc.stdout.readlines()
+        files   = ["/eos/uscms" + stub + "/" + file.rstrip() for file in payload]
+    else:
+        files = glob.glob("/eos/uscms" + query)
 
     return files
 
 def getDataSets(inPath):
-    l = glob(inPath+"/*")
-    print "-----------------------------------------------------------------------------" 
-    print red("Warning: No dataset specified: using all directory names in input path")
-    print "-----------------------------------------------------------------------------\n" 
-    return list(s[len(inPath)+1:] for s in l)
+    l = glob.glob(inPath+"/*")
+    print "-------------------------------------------------------" 
+    print cyan("Automatically hadding all directory names in input path")
+    print "-------------------------------------------------------\n" 
+    return list(path.split("/")[-1] for path in l)
 
 def main():
     # Parse command line arguments
@@ -72,6 +80,7 @@ def main():
     parser.add_argument('-H', dest='outDir',   type=str,            default = 'rootfiles',    help = "Can pass in the output directory name")
     parser.add_argument('-p', dest='inPath',   type=str,            default = 'output-files', help = "Can pass in the input directory name")
     parser.add_argument('-y', dest='year',     type=str,            default = '',             help = "Can pass in the year for this data")
+    parser.add_argument('-f',                  action='store_true',                           help = "ok to write in existing folder")
     parser.add_argument('-v',                  action='store_true',                           help = "make hadd verbose")
     parser.add_argument('-o',                  action='store_true',                           help = "Overwrite output directory")
     parser.add_argument('-m',                  action='store_true',                           help = "multiprocess, restricted to 4")
@@ -94,7 +103,7 @@ def main():
     if options.datasets:
         datasets = options.datasets.split(',')
     else:
-        datasets = getDataSets(inPath)
+        datasets = getDataSets("/eos/uscms" + stubPath + "/" + inPath)
 
     haddArgs = "-v 0"
     if options.v:
@@ -105,14 +114,15 @@ def main():
     # Check if output directory exits and makes it if not
     outDir = options.outDir
     overwrite = options.o
+    useSameDir = options.f
     if os.path.exists(outDir):
         if overwrite: 
-            print red("Warning: Overwriting output directory")
+            print red("Warning: Overwriting output directory !")
             shutil.rmtree(outDir)
             os.makedirs(outDir)
             pass
-        else:
-            print red("Error: Output directory %s already exits" % ('"'+outDir+'"'))
+        elif not useSameDir:
+            print red("Error: Output directory %s already exits ! Use option -f to OK writing into existing folder." % ('"'+outDir+'"'))
             exit(0)    
     else:
         os.makedirs(outDir) 
@@ -162,8 +172,10 @@ def main():
                     elif "_TTTo" in tempSample:
                         continue
 
-                    query = "%s/%s/%s/MyAnalysis_%s_*.root"%(stubPath, inPath, directory, tempSample)
-                    files = " ".join(listFiles(inPath, query))
+                    query = "%s/%s/%s/MyAnalysis_%s_[0-9]*.root"%(stubPath, inPath, directory, tempSample)
+
+                    eosCompatibility = "[" not in query and "]" not in query
+                    files = " ".join(listFiles(inPath, query, eosCompatibility))
 
                     outfile = "%s/%s.root" % (outDir, cleanName)
                     command = "hadd %s %s/%s.root %s" % (haddArgs, outDir, cleanName, files)
@@ -199,7 +211,7 @@ def main():
                     files = " ".join(listFiles(inPath, query))
                     
                     command = "hadd %s %s/%s.root %s" % (haddArgs, outDir, sampleCollection, files)
-                    if not options.noHadd: system(command)
+                    if not options.noHadd: os.system(command)
                     pass
     
                 log = checkNumEvents(nEvents=nEvents, rootFile=outfile, sampleCollection=sampleCollection, log=log)
@@ -209,18 +221,18 @@ def main():
             query_TT = "%s/%s/%s_AllBg/MyAnalysis_%s*TTTo*.root" % (stubPath, inPath, year, year)
             files_TT = " ".join(listFiles(inPath, query_TT)) 
             command = "hadd %s %s/%s_TT.root %s" % (haddArgs, outDir, year, files_TT)
-            system(command)
+            os.system(command)
 
             query_QCD = "%s/%s/%s_AllBg/MyAnalysis_%s*QCD*.root" % (stubPath, inPath, year, year)
             files_QCD = " ".join(listFiles(inPath, query_QCD))
             command = "hadd %s %s/%s_QCD.root %s" % (haddArgs, outDir, year, files_QCD)
-            system(command)
+            os.system(command)
 
             query_TTX1 = "%s/%s/%s_AllBg/MyAnalysis_%s*TT[WZ][TJ]*.root" % (stubPath, inPath, year, year)
             query_TTX2 = "%s/%s/%s_AllBg/MyAnalysis_%s*ttH*.root" % (stubPath,year, year)
             files_TTX = " ".join(listFiles(inPath, query_TTX1)) + " " + " ".join(listFiles(inPath, query_TTX2))
             command = "hadd %s %s/%s_TTX.root %s" % (haddArgs, outDir, year, files_TTX)
-            system(command)
+            os.system(command)
 
             query_DY = "%s/%s/%s_AllBg/MyAnalysis_%s*DYJets*.root" % (stubPath, inPath, year, year)
             query_2B = "%s/%s/%s_AllBg/MyAnalysis_%s_??_*.root" % (stubPath, inPath, year, year)
@@ -233,12 +245,12 @@ def main():
             files_Wj = " ".join(listFiles(inPath, query_Wj))
 
             command = "hadd %s %s/%s_BG_OTHER.root %s" % (haddArgs, outDir, year, files_DY + " " + files_2B + " " + files_3B + " " + files_Wj)
-            system(command)
+            os.system(command)
 
             query_Data = "%s/%s/%s_Data/MyAnalysis_%s*.root" % (stubPath, inPath, year, year)
             files_Data = " ".join(listFiles(inPath, query_Data))
             command = "hadd %s %s/%s_Data.root %s" % (haddArgs, outDir, year, files_Data)
-            system(command)
+            os.system(command)
 
     #Print log of hadd at the end
     printError(log)    
@@ -264,7 +276,7 @@ def main():
         print "-----------------------------------------------------------"
         print command
         print "-----------------------------------------------------------"
-        system(command)
+        os.system(command)
         
     if options.haddData:
         # Hack to make the Data.root file (hadd all the data together)
@@ -283,7 +295,7 @@ def main():
         print "-----------------------------------------------------------"
         print command
         print "-----------------------------------------------------------"
-        system(command)
+        os.system(command)
 
 if __name__ == "__main__":
     main()

--- a/Analyzer/test/condor/hadder.py
+++ b/Analyzer/test/condor/hadder.py
@@ -17,6 +17,20 @@ def cyan(string):
      CEND = "\033[0m"
      return CRED + str(string) + CEND
 
+def orange(string):
+     CRED = "\033[93m"
+     CEND = "\033[0m"
+     return CRED + str(string) + CEND
+
+def eosCompatible(query):
+
+    compatible = True
+    if "[" in query or "]" in query or "?" in query:
+        print cyan("Running in EOS compatiblity mode with \"ls\" rather than \"eosls\"")
+        compatible = False
+
+    return compatible
+
 def printError(log):
     if len(log) > 0:
          print red("------------------------------------------------------------------------------------------------")
@@ -51,10 +65,10 @@ def checkNumEvents(nEvents, rootFile, sampleCollection, log):
 
     return log
 
-def listFiles(inPath, query, eosCompatible=True):
+def listFiles(inPath, query):
 
     files = None
-    if eosCompatible:
+    if eosCompatible(query):
         stub = query.split("/MyAnalysis")[0]
         commandList = ["eos", "root://cmseos.fnal.gov", "ls", query]
 
@@ -109,6 +123,7 @@ def main():
     if options.v:
         haddArgs = "-v 99"
     if options.m:
+        print cyan("Running hadd multithreaded with 4 threads")
         haddArgs += " -j 4"
     
     # Check if output directory exits and makes it if not
@@ -124,6 +139,8 @@ def main():
         elif not useSameDir:
             print red("Error: Output directory %s already exits ! Use option -f to OK writing into existing folder." % ('"'+outDir+'"'))
             exit(0)    
+        else:
+            print orange("User OK'd writing hadded output to existing folder: \"%s\" !"%(outDir))
     else:
         os.makedirs(outDir) 
 
@@ -174,8 +191,7 @@ def main():
 
                     query = "%s/%s/%s/MyAnalysis_%s_[0-9]*.root"%(stubPath, inPath, directory, tempSample)
 
-                    eosCompatibility = "[" not in query and "]" not in query
-                    files = " ".join(listFiles(inPath, query, eosCompatibility))
+                    files = " ".join(listFiles(inPath, query))
 
                     outfile = "%s/%s.root" % (outDir, cleanName)
                     command = "hadd %s %s/%s.root %s" % (haddArgs, outDir, cleanName, files)

--- a/Analyzer/test/condor/runSplitSignal.sh
+++ b/Analyzer/test/condor/runSplitSignal.sh
@@ -14,7 +14,7 @@ for FOLDER in *mStop*
 do
     for FILE in $FOLDER/*
     do
-        xrdcp $FILE $OUTPUTDIR/$FOLDER/
+        xrdcp -f $FILE $OUTPUTDIR/$FOLDER/
     done
 done
 

--- a/Analyzer/test/condor/submitSplitSignal.py
+++ b/Analyzer/test/condor/submitSplitSignal.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
 
     fullInputPath = "%s/%s/%s/"%(args.eosPath, args.era, model)
 
-    USER = os.getenv("USER")
+    USER = "lpcsusyhad"
     outputDir = "/eos/uscms/store/user/%s/%s/%s"%(USER, args.outPath, args.era)
     for mass in masses:
         temp = ("%s/%s/"%(outputDir, model)).replace("300to1400", str(mass))


### PR DESCRIPTION
--fallback to simple `ls` commands when file list queries contain regex not supported by `eosls` e.g. `[]` and `?`.
--provided colored print out to better inform the user about what `hadder.py` is doing based on command line options
--provide `-f` option to tell `hadder.py` it is OK to write hadded output to a directory that already exists. This is especially useful when calling `hadder.py` multiple times on different input directories, but all the output is unique and go in one folder.

--slight tweaks to signal splitting code.