### PR TITLE
WIP: Update MiniTreeMaker for Skimming

### DIFF
--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -516,6 +516,19 @@ public:
             };
             registerModules(tr, std::move(modulesList));
         }
+        else if(analyzer=="MakeMiniTree")
+        {
+            const std::vector<std::string> modulesList = {
+                "PrepNTupleVars",
+                "Muon",
+                "Electron",
+                "Photon",
+                "Jet",
+                "BJet",
+                "CommonVariables",
+            };
+            registerModules(tr, std::move(modulesList));
+        }
         else
         {
             const std::vector<std::string> modulesList = {

--- a/Analyzer/include/MakeMiniTree.h
+++ b/Analyzer/include/MakeMiniTree.h
@@ -1,9 +1,8 @@
 #ifndef MakeMiniTree_h
 #define MakeMiniTree_h
 
-#include <TH1D.h>
-#include <TH2D.h>
 #include <TTree.h>
+#include <TH1D.h>
 
 #include <map>
 #include <string>
@@ -15,15 +14,15 @@ class MiniTupleMaker;
 class MakeMiniTree{
 
 public :
-   std::map<std::string, std::shared_ptr<TH1D>>  my_histos;
-   std::map<std::string, std::shared_ptr<TH2D>>  my_2d_histos;
+
+   std::shared_ptr<TH1D> eventCounter;
 
    MakeMiniTree();
    ~MakeMiniTree(){};
 
-   void     Loop(NTupleReader& tr, double weight, int maxevents = -1, bool isQuiet = false);
-   void     InitHistos();
-   void     WriteHistos(TFile* outfile); 
+   void Loop(NTupleReader& tr, double weight, int maxevents = -1, bool isQuiet = false);
+   void InitHistos();
+   void WriteHistos(TFile* outfile); 
 
    MiniTupleMaker *myMiniTuple;
    TTree          *myTree;

--- a/Analyzer/src/MakeMiniTree.cc
+++ b/Analyzer/src/MakeMiniTree.cc
@@ -10,110 +10,192 @@ MakeMiniTree::MakeMiniTree()
     InitHistos();
 }
 
-
 void MakeMiniTree::InitHistos()
 {
-    my_histos.emplace( "EventCounter", std::make_shared<TH1D>( "EventCounter", "EventCounter", 2, -1.1, 1.1 ) ); 
-}//END of init histos
+    eventCounter = std::make_shared<TH1D>("EventCounter", "EventCounter", 2, -1.1, 1.1);
+}
 
 void MakeMiniTree::Loop(NTupleReader& tr, double, int maxevents, bool)
 {
     while( tr.getNextEvent() )
     {
-        const auto& eventCounter        = tr.getVar<int>("eventCounter");
-        my_histos["EventCounter"]->Fill( eventCounter );
-
-        const auto& runtype             = tr.getVar<std::string>("runtype");
-        const auto& passBaseline1l      = tr.getVar<bool>("passBaseline1l_Good");
-       
         //------------------------------------
         //-- Print Event Number
         //------------------------------------
-        if( maxevents != -1 && tr.getEvtNum() >= maxevents ) break;
-        if( tr.getEvtNum() % 10000 == 0 ) printf( " Event %i\n", tr.getEvtNum() );
+        if( maxevents != -1 && tr.getEvtNum() > maxevents )
+            break;
+        if( tr.getEvtNum() % 1000 == 0 )
+            printf( " Event %i\n", tr.getEvtNum() );
+
+        eventCounter->Fill(1.0);
+
+        const auto& runtype         = tr.getVar<std::string>("runtype");
+
+        const auto& NGoodJets_pt30  = tr.getVar<int>("NGoodJets_pt30");
+        const auto& HT_trigger_pt30 = tr.getVar<double>("HT_trigger_pt30");
 
         //-----------------------------------
         //  Initialize the tree
         //-----------------------------------       
         std::set<std::string> variables = {
-            "FinalLumi",
-            "filetag",
-            "NGoodJets_pt30",
-            "NGoodBJets_pt30",
-            "passTriggerMC",
-            "Mbl",
-            "HT_trigger_pt30",
-            "HT",
-            "NGoodElectrons",
-            "NGoodMuons",
-            "MET",
-            "NVtx",
-            "bTagSF_EventWeightSimple_Central",
-            "htDerivedweight",
-            "htDerivedweightFlat2000",
-            "htDerivedweightNJet7",
-            "prefiringScaleFactor",
-            "totGoodMuonSF",
-            "totGoodElectronSF",
-            "puWeightCorr",
+            // Event-level
+            "RunNum",
             "Weight",
-            "totalEventWeight",
-        };
-        if( runtype != "MC" ) {
-            variables = {
-            "FinalLumi",
-            "filetag",
-            "NGoodJets_pt30",
-            "NGoodBJets_pt30",
-            "Mbl",
-            "NVtx",
-            "HT_trigger_pt30",
-            "HT",
-            "NGoodElectrons",
-            "NGoodMuons",
+            "TriggerPass",
+    
+            // Electrons
+            "Electrons",
+            "Electrons_passIso",
+            "Electrons_iso",
+            "Electrons_charge",
+            "Electrons_tightID",
+
+            // Muons
+            "Muons",
+            "Muons_passIso",
+            "Muons_iso",
+            "Muons_charge",
+            "Muons_mediumID",
+
+            // Photons
+            "Photons",
+            "Photons_fullID",
+    
+            // MET
             "MET",
-            };
+            "METPhi",
+
+            // Jets
+            "Jets",
+            "Jets_origIndex",
+            "JetsJECup_origIndex",
+            "JetsJECdown_origIndex",
+            "JetsJERup_origIndex",
+            "JetsJERdown_origIndex",
+            "Jets_jerFactor",
+            "Jets_jecUnc",
+            "JetsJECup_jerFactor",
+            "JetsJECdown_jerFactor",
+            "Jets_jerFactorUp",
+            "Jets_jerFactorDown",
+            "Jets_bDiscriminatorCSV" ,
+            "Jets_bJetTagDeepCSVprobb",
+            "Jets_bJetTagDeepCSVprobbb",
+            "Jets_bJetTagDeepFlavourprobb",
+            "Jets_bJetTagDeepFlavourprobbb",
+            "Jets_bJetTagDeepFlavourprobc",
+            "Jets_bJetTagDeepFlavourprobuds",
+            "Jets_bJetTagDeepFlavourprobg",
+            "Jets_bJetTagDeepCSVprobc",
+            "Jets_bJetTagDeepCSVprobudsg",
+            "Jets_qgLikelihood",
+            "Jets_muonEnergyFraction",
+            "Jets_hfHadronEnergyFraction",
+            "Jets_hfEMEnergyFraction",
+            "Jets_photonEnergyFraction",
+            "Jets_electronEnergyFraction",
+            "Jets_chargedHadronMultiplicity",
+            "Jets_neutralHadronMultiplicity",
+            "Jets_photonMultiplicity",
+            "Jets_electronMultiplicity",
+            "Jets_muonMultiplicity",
+            "Jets_ID",
+            "JetID",
+            "Jets_partonFlavor",
+            "Jets_ptD",
+            "Jets_axismajor",
+            "Jets_axisminor",
+            "Jets_multiplicity",
+            "Jets_neutralEmEnergyFraction",
+            "Jets_chargedEmEnergyFraction",
+            "Jets_neutralHadronEnergyFraction",
+            "Jets_chargedHadronEnergyFraction",
+
+            // JetsAK8
+            "JetsAK8",
+            "JetsAK8_origIndex",
+            "JetsAK8JECup_origIndex",
+            "JetsAK8JECdown_origIndex",
+            "JetsAK8JERup_origIndex",
+            "JetsAK8JERdown_origIndex",
+            "JetsAK8_jerFactor",
+            "JetsAK8_jecUnc",
+            "JetsAK8JECup_jerFactor",
+            "JetsAK8JECdown_jerFactor",
+            "JetsAK8_jerFactorUp",
+            "JetsAK8_jerFactorDown",
+            "JetsAK8_NsubjettinessTau1",
+            "JetsAK8_NsubjettinessTau2",
+            "JetsAK8_NsubjettinessTau3",
+            "JetsAK8_softDropMass",
+            "JetsAK8_axismajor",
+            "JetsAK8_axisminor",
+            "JetsAK8_subjets",
+            "JetsAK8_subjetsCounts",
+            "JetsAK8_DeepTagTvsQCD",
+            "JetsAK8_DeepTagWvsQCD",
+            "JetsAK8_DeepTagHbbvsQCD",
+            "JetsAK8_multiplicity",
+
+            // Event filters
+            "globalSuperTightHalo2016Filter",
+            "PrimaryVertexFilter",
+            "BadPFMuonFilter",
+            "EcalDeadCellTriggerPrimitiveFilter",
+            "HBHEIsoNoiseFilter",
+            "HBHENoiseFilter",
+        };
+
+        if( runtype == "MC" )
+        {
+            variables.insert("madHT");
+            variables.insert("GenElectrons");
+            variables.insert("GenMuons");
+            variables.insert("GenTaus");
+            variables.insert("GenMET");
+            variables.insert("GenMETPhi");
+            variables.insert("GenParticles");
+            variables.insert("GenParticles_PdgId");
+            variables.insert("GenParticles_ParentId");
+            variables.insert("GenParticles_ParentIdx");
+            variables.insert("GenParticles_Status");
+            variables.insert("ScaleWeights");
+            variables.insert("PSweights");
+            variables.insert("PDFweights");
+            variables.insert("puWeight");
+            variables.insert("puSysUp");
+            variables.insert("puSysDown");
+            variables.insert("NonPrefiringProb");
+            variables.insert("NonPrefiringProbUp");
+            variables.insert("NonPrefiringProbDown");
+
         }
+
         if( tr.isFirstEvent() ) {
-            std::string myTreeName = "myMiniTree";
+            std::string myTreeName = "SkimmedTree";
             myTree = new TTree( (myTreeName).c_str() , (myTreeName).c_str() );
             myMiniTuple = new MiniTupleMaker( myTree );
             myMiniTuple->setTupleVars(variables);
             myMiniTuple->initBranches(tr);
         }
         
-        if( runtype == "MC" ) {
-            const auto& passTriggerMC       = tr.getVar<bool>("passTriggerMC");
-            const auto& passMadHT           = tr.getVar<bool>("passMadHT");
-            
-            if( !passMadHT || !passTriggerMC ) continue; 
-        }
-
         //-----------------------------------
         //-- Fill Histograms Below
         //-----------------------------------
-        if( passBaseline1l ) {
+        if( true ) {
+            eventCounter->Fill(-1.0);
             myMiniTuple->fill();
         }
-
-    }//END of while tr.getNextEvent loop   
-}//END of function
+    } 
+}
       
 void MakeMiniTree::WriteHistos( TFile* outfile ) 
 {
     outfile->cd();
-
-    for (const auto &p : my_histos) {
-        p.second->Write();
-    }
-    
-    for (const auto &p : my_2d_histos) {
-        p.second->Write();
-    }
-
     myTree->Write();
+    eventCounter->Write();
+
     delete myTree;    
     delete myMiniTuple;
 
 }
-


### PR DESCRIPTION
This PR updates `MiniTreeMaker.h` for producing skimmed ntuples. The companion PR in `Framework` is: https://github.com/StealthStop/Framework/pull/337

**WIP is due to still needing to finalize the exactly skimming selection.**

--spin off separate block in `Config.h` to run minimal amount of modules for `MiniTreeMaker`.
--include one `eventCounter` histogram to keep track of total number of events processed and number of successfully skimmed events.
--include full minimal list of variables to include in skimmed ntuple files (only those necessary to run modules requested by `AnalyzeDoubleDisCo`.
