### PR TITLE
CalculateSFMean Does Not Need to Run BTagCorrector

### DIFF
--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -392,7 +392,7 @@ public:
             };
             registerModules(tr, std::move(modulesList));
         }
-        else if(analyzer=="AnalyzeLepTrigger" || analyzer=="HadTriggers_Analyzer" || analyzer=="CalculateSFMean")
+        else if(analyzer=="AnalyzeLepTrigger" || analyzer=="HadTriggers_Analyzer")
         {
             const std::vector<std::string> modulesList = {
                 "PrepNTupleVars",
@@ -419,6 +419,21 @@ public:
                 "CommonVariables",
                 "RunTopTagger",
                 "Baseline",
+            };
+            registerModules(tr, std::move(modulesList));
+        }
+        else if(analyzer=="CalculateSFMean")
+        {
+            const std::vector<std::string> modulesList = {
+                "PrepNTupleVars",
+                "Muon",
+                "Electron",
+                "Jet",
+                "BJet",
+                "CommonVariables",
+                "RunTopTagger",
+                "Baseline",
+                "ScaleFactors",
             };
             registerModules(tr, std::move(modulesList));
         }


### PR DESCRIPTION
At the current time, `CalculateSFMean` does not need to run `BTagCorrector`, so remove from the list of modules in `Config.h`.
A safety measure is performed in `ScaleFactors` to not try and get the BTagSF, specifically when running this `CalculateSFMean` analyzer. See companion PR: https://github.com/StealthStop/Framework/pull/344