### PR TITLE
Avoid JEC/JER Variation for Data

### DIFF
--- a/Analyzer/include/AnalyzeDoubleDisCo.h
+++ b/Analyzer/include/AnalyzeDoubleDisCo.h
@@ -3,7 +3,6 @@
 
 #include <TH1D.h>
 #include <TH2D.h>
-#include <TTree.h>
 #include <TFile.h>
 
 #include <map>
@@ -58,7 +57,7 @@ public:
     void makeSubregions(const std::vector<std::vector<std::string>>& regionsVec);
     void Loop(NTupleReader& tr, double weight, int maxevents = -1, bool isQuiet = false);
     void Preinit(unsigned int, unsigned int);
-    void InitHistos(const std::map<std::string, bool>& cutMap, const std::vector<std::vector<std::string>>& regionsVec);
+    void InitHistos(const std::map<std::string, bool>& cutMap, const std::vector<std::vector<std::string>>& regionsVec, const std::string& runtype);
     void WriteHistos(TFile* outfile);
     void Debug(const std::string& message, int line);
 

--- a/Analyzer/src/AnalyzeDoubleDisCo.cc
+++ b/Analyzer/src/AnalyzeDoubleDisCo.cc
@@ -223,7 +223,7 @@ void AnalyzeDoubleDisCo::Preinit(unsigned int nNNJets, unsigned int nLeptons)
     }
 }
 
-void AnalyzeDoubleDisCo::InitHistos(const std::map<std::string, bool>& cutMap, const std::vector<std::vector<std::string>>& regionsVec)
+void AnalyzeDoubleDisCo::InitHistos(const std::map<std::string, bool>& cutMap, const std::vector<std::vector<std::string>>& regionsVec, const std::string& runtype)
 {
 
     Debug("Initializing all histograms", __LINE__);
@@ -261,6 +261,10 @@ void AnalyzeDoubleDisCo::InitHistos(const std::map<std::string, bool>& cutMap, c
                 // --------------------------------------------------------------------------
                 for (const auto& ttvar : ttvars)
                 {
+                    // Variations irrelevant for data
+                    if (ttvar != "nom" and runtype == "Data")
+                        continue;
+
                     std::string ttvarStr = "";
                     if (ttvar != "nom")
                         ttvarStr = "_" + ttvar; 
@@ -270,6 +274,9 @@ void AnalyzeDoubleDisCo::InitHistos(const std::map<std::string, bool>& cutMap, c
                     // -------------------------------------------------------------
                     for (const auto& jecvar : jecvars)
                     {
+                        // Variations irrelevant for data
+                        if (jecvar != "" and runtype == "Data")
+                            continue;
 
                         // We don't do double variations
                         if (jecvar != "" and ttvar != "nom")
@@ -353,6 +360,10 @@ void AnalyzeDoubleDisCo::InitHistos(const std::map<std::string, bool>& cutMap, c
                 // --------------------------------------------------------------------------
                 for (const auto& ttvar : ttvars)
                 {   
+                    // Variations irrelevant for data
+                    if (ttvar != "nom" and runtype == "Data")
+                        continue;
+
                     std::string ttvarStr = "";
                     if (ttvar != "nom")
                         ttvarStr = "_" + ttvar;
@@ -363,7 +374,11 @@ void AnalyzeDoubleDisCo::InitHistos(const std::map<std::string, bool>& cutMap, c
                     for (const auto& jecvar : jecvars)
                     {
 
-                        // We don't do double variations
+                       // Variations irrelevant for data
+                       if (jecvar != "" and runtype == "Data")
+                           continue;
+
+                       // We don't do double variations
                         if (jecvar != "" and ttvar != "nom")
                             continue;
 
@@ -1069,7 +1084,7 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
                 Debug("Initializing the histograms", __LINE__);
 
                 Preinit(7, 2);
-                InitHistos(cut_map, regions);
+                InitHistos(cut_map, regions, runtype);
                 initHistos = true;
             }
 

--- a/Analyzer/src/AnalyzeDoubleDisCo.cc
+++ b/Analyzer/src/AnalyzeDoubleDisCo.cc
@@ -373,7 +373,6 @@ void AnalyzeDoubleDisCo::InitHistos(const std::map<std::string, bool>& cutMap, c
                     // -------------------------------------------------------------
                     for (const auto& jecvar : jecvars)
                     {
-
                        // Variations irrelevant for data
                        if (jecvar != "" and runtype == "Data")
                            continue;
@@ -1156,6 +1155,9 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
                         std::string ttvarStr = "";
                         if (ttvar != "nom")
                             ttvarStr = "_" + ttvar; 
+
+                        if (ttvar != "nom" and runtype == "Data")
+                            continue;
 
                         if (ttvar != "nom" and jecvar != "")
                             continue;

--- a/Analyzer/src/AnalyzeDoubleDisCo.cc
+++ b/Analyzer/src/AnalyzeDoubleDisCo.cc
@@ -434,6 +434,9 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
 
     for(const auto& jecvar : jecvars)
     {
+        // Cannot do JEC and JER variations for data
+        if (jecvar != "" and runtype == "Data")
+            continue;
 
         Jet                 jet(jecvar);
         BJet                bjet(jecvar);
@@ -519,6 +522,10 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
 
         for(const auto& jecvar : jecvars)
         {
+            // Cannot do JEC and JER variations for data
+            if (jecvar != "" and runtype == "Data")
+                continue;
+
             std::string jecStr = "";
             if (jecvar != "")
                 jecStr = "_" + jecvar;


### PR DESCRIPTION
--in `AnalyzeDoubleDisCo`, do not attempt to do JEC or JER variations when running on data. The user will be sad.
--no point in filling histos for ISR/FSR variations either for data.