### PR TITLE
Let User Override Username

### DIFF
--- a/Analyzer/test/condor/condorSubmit.py
+++ b/Analyzer/test/condor/condorSubmit.py
@@ -41,6 +41,7 @@ def main():
     parser.add_option ('-L',        dest='dataCollectionslong',     action='store_true', default = False,         help="List all datacollections and sub collections")
     parser.add_option ('-c',        dest='noSubmit',                action='store_true', default = False,         help="Do not submit jobs.  Only create condor_submit.txt.")
     parser.add_option ('-s',        dest='fastMode',                action='store_true', default = False,         help="Run Analyzer in fast mode")
+    parser.add_option ('-u',        dest='userOverride',  type='string',                 default = '',            help="Override username with something else")
     parser.add_option ('--output',  dest='outPath',  type='string',                      default = '.',           help="Name of directory where output of each condor job goes")
     parser.add_option ('--analyze', dest='analyze',                                      default = 'Analyze1Lep', help="AnalyzeBackground, AnalyzeEventSelection, Analyze0Lep, Analyze1Lep, MakeNJetDists")    
     options, args = parser.parse_args()
@@ -49,10 +50,10 @@ def main():
     testDir  = environ["CMSSW_BASE"] + "/src/%s/test"%(repo) 
     userName = environ["USER"]
 
-    hostName = environ["HOSTNAME"]
+    if options.userOverride != "":
+        userName = options.userOverride
 
-    if "uscms.org" in hostName:
-        system("source /etc/ciconnect/set_condor_sites.sh \"T[1-2]_US_*\"") 
+    hostName = environ["HOSTNAME"]
 
     redirector = "root://cmseos.fnal.gov/"
     workingDir = options.outPath


### PR DESCRIPTION
The `userName` specified in `condorSubmit.py` has traditionally been picked up from the `$USER` environment variable. It may be the case that it is helpful to override the username with something specified on the commandline. It is useful if one's userName is not the same on CMS Connect vs LPC or if wanting to write to a group EOS space like `lpcsusystealth`, rather than a personal EOS space. This is what the PR adds as an option. The username is in fact only used for determining the output destination of the job output.

Also, remove attempt to source `.sh` script when running on CMS Connect. Can easily just source normally outside of python.