### PR TITLE
Handle Two Types of Event Counts

### DIFF
--- a/Analyzer/test/condor/samples.py
+++ b/Analyzer/test/condor/samples.py
@@ -13,7 +13,8 @@ class SampleCollection:
         self.obj = self.lib.SC_new(self.ss, scfile)
         self.lib.SC_samples.restype = POINTER(c_char_p)
         self.lib.SC_samples_names.restype = POINTER(c_char_p)
-        self.lib.SC_samples_nEvts.restype = POINTER(c_int)
+        self.lib.SC_samples_nGenEvts.restype = POINTER(c_int)
+        self.lib.SC_samples_nActEvts.restype = POINTER(c_int)
         self.lib.SS_samples.restype = POINTER(c_char_p)
         self.lib.SS_samples_names.restype = POINTER(c_char_p)
         self.lib.SC_samplecollection_names.restype = POINTER(c_char_p)
@@ -24,8 +25,9 @@ class SampleCollection:
     def sampleList(self, name):
         files = self.lib.SC_samples(self.obj, name)
         names = self.lib.SC_samples_names(self.obj, name)
-        nEvts = self.lib.SC_samples_nEvts(self.obj, name)
-        list = [(files[i],names[i],nEvts[i]) for i in xrange(self.lib.SC_samples_size(self.obj, name))]
+        nGenEvts = self.lib.SC_samples_nGenEvts(self.obj, name)
+        nActEvts = self.lib.SC_samples_nActEvts(self.obj, name)
+        list = [(files[i],names[i],nActEvts[i]) for i in xrange(self.lib.SC_samples_size(self.obj, name))]
         return list
 
     def sampleCollectionList(self):

--- a/Analyzer/test/condor/samples.py
+++ b/Analyzer/test/condor/samples.py
@@ -13,7 +13,6 @@ class SampleCollection:
         self.obj = self.lib.SC_new(self.ss, scfile)
         self.lib.SC_samples.restype = POINTER(c_char_p)
         self.lib.SC_samples_names.restype = POINTER(c_char_p)
-        self.lib.SC_samples_nGenEvts.restype = POINTER(c_int)
         self.lib.SC_samples_nActEvts.restype = POINTER(c_int)
         self.lib.SS_samples.restype = POINTER(c_char_p)
         self.lib.SS_samples_names.restype = POINTER(c_char_p)
@@ -25,7 +24,6 @@ class SampleCollection:
     def sampleList(self, name):
         files = self.lib.SC_samples(self.obj, name)
         names = self.lib.SC_samples_names(self.obj, name)
-        nGenEvts = self.lib.SC_samples_nGenEvts(self.obj, name)
         nActEvts = self.lib.SC_samples_nActEvts(self.obj, name)
         list = [(files[i],names[i],nActEvts[i]) for i in xrange(self.lib.SC_samples_size(self.obj, name))]
         return list


### PR DESCRIPTION
Companion PR: https://github.com/StealthStop/Framework/pull/355

Acknowledge that there is now a *generated* event counts and *actual* event counts that could be coming from the filelist. For hadding purposes (to verify if all events in a sample were run over) we return `nActEvts` in the `sampleList` function.