### PR TITLE
updating for triggerr scale factors

### DIFF
--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -152,7 +152,7 @@ public:
         std::string DoubleDisCo_Model_2l_SYY          = "keras_frozen_DoubleDisCo_Reg_2l_SYY_Run2.pb";
         std::string DoubleDisCo_Cfg_NonIsoMuon_2l_SYY = "Keras_Tensorflow_NonIsoMuon_DoubleDisCo_Reg_2l_SYY_Run2.cfg";
         // SF root files
-        std::string leptonFileName                    = "allInOne_leptonSF_UL.root";
+        std::string leptonFileName                    = "allInOne_leptonicSF_UL.root";
         std::string hadronicFileName                  = "allInOne_hadronicSF_UL.root";
         std::string btagEffFileName                   = "allInOne_BTagEff_UL.root";
         std::string meanFileName                      = "allInOne_SFMean_UL.root";

--- a/Analyzer/test/setup.sh
+++ b/Analyzer/test/setup.sh
@@ -37,7 +37,7 @@ fi
 # Check needed SF files and ensure local file matches with EOS file
 # Only copy down from EOS if necessary
 sfPath="$redirector/store/user/lpcsusystealth/StealthStop/ScaleFactorHistograms/FullRun2_UL"
-sfFiles=("wp_deepJet_106XUL16preVFP_v2.csv" "wp_deepJet_106XUL16postVFP_v3.csv" "wp_deepJet_106XUL17_v3.csv" "wp_deepJet_106XUL18_v2.csv" "allInOne_leptonSF_UL.root" "allInOne_hadronicSF_UL.root" "allInOne_BTagEff_UL.root" "allInOne_SFMean_UL.root")
+sfFiles=("wp_deepJet_106XUL16preVFP_v2.csv" "wp_deepJet_106XUL16postVFP_v3.csv" "wp_deepJet_106XUL17_v3.csv" "wp_deepJet_106XUL18_v2.csv" "allInOne_leptonicSF_UL.root" "allInOne_hadronicSF_UL.root" "allInOne_BTagEff_UL.root" "allInOne_SFMean_UL.root")
 for i in ${!sfFiles[@]};
 do
     sfFile=${sfFiles[$i]}


### PR DESCRIPTION
I updated the Jet, Electron and Muon trigger SFs. because we switched to the DeepFlavor for b-tagging.

**Jet trigger SFs:**

1. I got two histograms for jet SFs: one with exactly 1b, another ≥2b
2. Also, I renamed the histograms

**Electron and Muon SFs**

1. I used the same electron and muon SFs for 1l and 2l channels.
2. Also, I renamed the histograms

