### PR TITLE
Updates for Job Submission

### DIFF
--- a/Analyzer/test/condor/cleanupSubmit.py
+++ b/Analyzer/test/condor/cleanupSubmit.py
@@ -28,6 +28,22 @@ def listPath(path, onEOS=False):
     for line in payload:
         line = str(line).rstrip("\n")
 
+        # Check the size, if clearly a broken file (< 512 bytes) do not count as "done"
+        if ".root" in line:
+
+            proc = subprocess.Popen(["xrdfs", "root://cmseos.fnal.gov", "stat", line], stdout=subprocess.PIPE)
+            info = proc.stdout.readlines()
+            size = None
+            for stat in info:
+                if "Size" in stat:
+                    size = stat.partition("Size:")[-1].replace(" ", "").rstrip()
+                    break
+                else:
+                    continue
+                    
+            if int(size) < 512:
+                continue
+
         # Ensure that each element in the list has its full path
         if not onEOS:
             line = path + "/" + line

--- a/Analyzer/test/condor/cleanupSubmit.py
+++ b/Analyzer/test/condor/cleanupSubmit.py
@@ -139,6 +139,7 @@ def main():
     fileParts.append("Universe             = vanilla\n")
     fileParts.append("Executable           = run_Analyzer_condor.sh\n")
     fileParts.append("Transfer_Input_Files = %s/%s.tar.gz, %s/exestuff.tar.gz\n" % (options.jobdir,os.environ["CMSSW_VERSION"],options.jobdir))
+    fileParts.append("Request_Memory       = 2.5 Gb\n")
     fileParts.append("x509userproxy        = $ENV(X509_USER_PROXY)\n\n")
 
     nJob = 0

--- a/Analyzer/test/condor/condorSubmit.py
+++ b/Analyzer/test/condor/condorSubmit.py
@@ -102,10 +102,6 @@ def main():
     workingDir = options.outPath
     eosDir     = "%s/store/user/%s/StealthStop/%s"%(redirector, userName, options.outPath)
 
-    #if os.path.isdir(workingDir):
-    #    print red("Job directory already exists and cannot proceed safely ! Exiting...")
-    #    exit(0)
-
     # Prepare the list of files to transfer
     mvaFileName2016preVFP  = getTopTaggerTrainingFile(environ["CMSSW_BASE"] + "/src/%s/test/TopTaggerCfg_2016preVFP.cfg" % repo)
     mvaFileName2016postVFP = getTopTaggerTrainingFile(environ["CMSSW_BASE"] + "/src/%s/test/TopTaggerCfg_2016postVFP.cfg" % repo)
@@ -202,6 +198,9 @@ def main():
         # create the directory
         if not os.path.isdir("%s/%s" %(workingDir, logsDir)):
             system('mkdir -p %s/%s' %(workingDir, logsDir))
+        else:
+            print red("Job directory \"%s/%s\" already exists and cannot proceed safely ! Exiting..."%(workingDir, logsDir))
+            exit(0)
    
         for s, n, e in sc.sampleList(ds):
 

--- a/Analyzer/test/condor/condorSubmit.py
+++ b/Analyzer/test/condor/condorSubmit.py
@@ -102,9 +102,9 @@ def main():
     workingDir = options.outPath
     eosDir     = "%s/store/user/%s/StealthStop/%s"%(redirector, userName, options.outPath)
 
-    if os.path.isdir(workingDir):
-        print red("Job directory already exists and cannot proceed safely ! Exiting...")
-        exit(0)
+    #if os.path.isdir(workingDir):
+    #    print red("Job directory already exists and cannot proceed safely ! Exiting...")
+    #    exit(0)
 
     # Prepare the list of files to transfer
     mvaFileName2016preVFP  = getTopTaggerTrainingFile(environ["CMSSW_BASE"] + "/src/%s/test/TopTaggerCfg_2016preVFP.cfg" % repo)
@@ -189,6 +189,7 @@ def main():
     fileParts.append("Universe             = vanilla\n")
     fileParts.append("Executable           = run_Analyzer_condor.sh\n")
     fileParts.append("Transfer_Input_Files = %s/%s.tar.gz, %s/exestuff.tar.gz\n" % (options.outPath,environ["CMSSW_VERSION"],options.outPath))
+    fileParts.append("Request_Memory       = 2.5 Gb\n")
     fileParts.append("x509userproxy        = $ENV(X509_USER_PROXY)\n\n")
 
     nFilesPerJob = options.numfile

--- a/Analyzer/test/condor/hadder.py
+++ b/Analyzer/test/condor/hadder.py
@@ -168,6 +168,8 @@ def main():
                                 "2016preVFP_AllTT",     "2016postVFP_AllTT",     "2017_AllTT",     "2018_AllTT",
                                 "2016preVFP_RPV",       "2016postVFP_RPV",       "2017_RPV",       "2018_RPV",
                                 "2016preVFP_StealthSYY","2016postVFP_StealthSYY","2017_StealthSYY","2018_StealthSYY",
+                                "2016preVFP_TTX_skim",  "2016postVFP_TTX_skim",  "2017_TTX_skim",  "2018_TTX_skim",
+                                "2016preVFP_TTX",  "2016postVFP_TTX",  "2017_TTX",  "2018_TTX",
                                 ]
 
             if sampleCollection in sampleSetsToHadd:


### PR DESCRIPTION
Explicitly request 2.5 GB of memory for Analyzer condor jobs (just started hitting implicit limit of 2048 MB for `AnalyzeDoubleDisCo`).
Update `cleanupSubmit.py` to check the output ROOT file sizes. If the file is clearly empty (< 512 B), then do not count the job as "done". Count the job as needed to be rerun.