### PR TITLE
QCD Validation Study

### DIFF
--- a/Analyzer/include/Config.h
+++ b/Analyzer/include/Config.h
@@ -506,6 +506,40 @@ public:
             };
             registerModules(tr, std::move(modulesList));
         }
+        else if(analyzer=="MakeQCDValTree")
+        {
+            fastModeCompatible = true;
+            const std::vector<std::string> modulesList = {
+                "PrepNTupleVars",
+                "Muon",
+                "Electron",
+                "Photon",
+                "Jet",
+                "BJet",
+                "CommonVariables",
+                "RunTopTagger",
+                "Baseline",
+                "MakeMVAVariables",
+                "MakeMVAVariables_NonIsoMuon",
+                "StopJets",
+                "MakeStopHemispheres_TopSeed",
+                "MakeStopHemispheres_OldSeed",
+                "MakeStopHemispheres_TopSeed_NonIsoMuon",
+                "MakeStopHemispheres_OldSeed_NonIsoMuon",
+                "BTagCorrector",
+                "ScaleFactors",
+                "StopGenMatch",
+                "DoubleDisCo_0l_RPV",
+                "DoubleDisCo_NonIsoMuon_0l_RPV",
+                "DoubleDisCo_0l_SYY",
+                "DoubleDisCo_NonIsoMuon_0l_SYY",
+                "DoubleDisCo_1l_RPV",
+                "DoubleDisCo_NonIsoMuon_1l_RPV",
+                "DoubleDisCo_1l_SYY",
+                "DoubleDisCo_NonIsoMuon_1l_SYY",
+            };
+            registerModules(tr, std::move(modulesList));
+        }
         else
         {
             const std::vector<std::string> modulesList = {
@@ -530,7 +564,6 @@ public:
             std::cerr << utility::color("Error: Analyzer \"" + analyzer + "\" is not compatible with fast mode !!! Exiting...", "red") << std::endl;
             exit(-1);
         }
-
     }
 };
 

--- a/Analyzer/include/MakeQCDValTree.h
+++ b/Analyzer/include/MakeQCDValTree.h
@@ -1,0 +1,33 @@
+#ifndef MakeQCDValTree_h
+#define MakeQCDValTree_h
+
+#include <TTree.h>
+#include <TH1D.h>
+
+#include <map>
+#include <string>
+
+class NTupleReader;
+
+class MiniTupleMaker;
+
+class MakeQCDValTree{
+
+public :
+
+   std::shared_ptr<TH1D> eventCounter;
+
+   MakeQCDValTree();
+   ~MakeQCDValTree(){};
+
+   void Loop(NTupleReader& tr, double weight, int maxevents = -1, bool isQuiet = false);
+   void InitHistos();
+   void WriteHistos(TFile* outfile); 
+
+   MiniTupleMaker *myQCDValTuple;
+   TTree          *myTree;
+
+   bool treeInit;
+};
+
+#endif

--- a/Analyzer/src/AnalyzeDoubleDisCo.cc
+++ b/Analyzer/src/AnalyzeDoubleDisCo.cc
@@ -86,6 +86,7 @@ AnalyzeDoubleDisCo::AnalyzeDoubleDisCo() : initHistos(false)
         {"h_njets_13incl_SYY",             24, -0.5, 23.5},
         {"h_HT",                          720,    0, 7200},
         {"h_dRbjets",                     180,    0,    6},
+        {"h_Mbb",                         720,    0,  720},
         {"h_Mbl",                         180,    0,  360},
         {"h_Mll",                         180,    0,  360},
         {"h_Stop1_mass_PtRank_matched",   180,    0, 1800},
@@ -281,6 +282,9 @@ void AnalyzeDoubleDisCo::InitHistos(const std::map<std::string, bool>& cutMap, c
                         continue;
                 }
 
+                if (mycut.first.find("blind") != std::string::npos and Njet != "Incl")
+                    continue;
+
                 // --------------------------------------------------------------------------
                 // loop over the systvars fsrUp/Down, isrUp/Down, etc.
                 // to make indivudual histograms with the label systvars in root file
@@ -386,6 +390,9 @@ void AnalyzeDoubleDisCo::InitHistos(const std::map<std::string, bool>& cutMap, c
                     if (h2dInfo.name.find("DoubleDisCo") == std::string::npos)
                         continue;
                 }
+
+                if (mycut.first.find("blind") != std::string::npos and Njet != "Incl")
+                    continue;
 
                 // --------------------------------------------------------------------------
                 // loop over the systvars fsrUp/Down, isrUp/Down
@@ -668,6 +675,7 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
             std::vector<double>                                     Mbl_CR                         ;
             std::vector<double>                                     Mll_CR                         ;
             std::vector<double>                                     dRbjets_CR                     ;
+            std::vector<double>                                     Mbb_CR                         ;
             std::vector<double>                                     HT_pt30_CR                     ;
             std::vector<double>                                     DoubleDisCo_RPV_massReg_CR     ;
             std::vector<double>                                     DoubleDisCo_RPV_disc1_CR       ;
@@ -796,6 +804,7 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
             std::vector<double>                                     HT_pt30                        ;
             std::vector<double>                                     Mbl                            ;
             std::vector<double>                                     Mll                            ;
+            std::vector<double>                                     Mbb                            ;
             std::vector<double>                                     dRbjets                        ;
             std::vector<double>                                     DoubleDisCo_RPV_massReg        ;
             std::vector<double>                                     DoubleDisCo_RPV_disc1          ;
@@ -891,12 +900,14 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
                 std::string flavName = "NonIsoMuons";
                 std::string jetsName = "NonIsoMuon";
                 std::string htName   = "NonIsoMuon";
+                std::string nimName  = "nim";
                 if (channel != "1")
                 {
                     mvaName  = "";
                     flavName = "";
                     jetsName = "Good";
                     htName   = "trigger";
+                    nimName  = "";
                 }
 
                 Jets.push_back(tr.getVec<utility::LorentzVector>("Jets"                       + jecvar));
@@ -922,6 +933,7 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
                 Baseline_blind.push_back(tr.getVar<bool>("passBaseline" + channel + "l_Good_blind" + jecvar));
                 Mbl.push_back(tr.getVar<double>("Mbl"                                              + jecvar));
                 Mll.push_back(tr.getVar<double>("mll"                                              + jecvar));
+                Mbb.push_back(tr.getVar<double>("Mbb"                                              + jecvar));
                 dRbjets.push_back(tr.getVar<double>("dR_bjets"                                     + jecvar));
 
                 DoubleDisCo_RPV_massReg.push_back(tr.getVar<double>("DoubleDisCo_massReg_" + channel + "l_RPV" + jecvar));
@@ -1071,7 +1083,8 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
 
                 Mbl_CR.push_back(tr.getVar<double>("Mbl"                           + jecvar));
                 Mll_CR.push_back(tr.getVar<double>("mll"                           + jecvar));
-                dRbjets_CR.push_back(tr.getVar<double>("dR_bjets"                  + jecvar));
+                Mbb_CR.push_back(tr.getVar<double>(nimName + "Mbb"                 + jecvar));
+                dRbjets_CR.push_back(tr.getVar<double>("dR_" + nimName + "bjets"   + jecvar));
 
                 DoubleDisCo_RPV_massReg_CR.push_back(tr.getVar<double>("DoubleDisCo_massReg_NonIsoMuon_" + channel + "l_RPV"  + jecvar));
                 DoubleDisCo_RPV_disc1_CR.push_back(tr.getVar<double>("DoubleDisCo_disc1_NonIsoMuon_" + channel + "l_RPV"      + jecvar));
@@ -1291,25 +1304,25 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
 
             const std::map<std::string, bool> cut_map
             {
-                {"_0l"            , Baseline[0]},
-                {"_1l"            , Baseline[1]},
-                {"_1l_el"         , Baseline[1] and NGoodElectrons == 1},
-                {"_1l_mu"         , Baseline[1] and NGoodMuons     == 1},
-                {"_2l"            , Baseline[2]},
-                {"_2l_elel"       , Baseline[2] and NGoodElectrons == 2},
-                {"_2l_mumu"       , Baseline[2] and NGoodMuons     == 2},
-                {"_2l_elmu"       , Baseline[2] and NGoodElectrons == 1 and NGoodMuons == 1},
-                {"_0l_blind"      , Baseline_blind[0]},
-                {"_1l_blind"      , Baseline_blind[1]},                         
-                {"_1l_blind_el"   , Baseline_blind[1] and NGoodElectrons == 1},
-                {"_1l_blind_mu"   , Baseline_blind[1] and NGoodMuons     == 1},
-                {"_2l_blind"      , Baseline_blind[2]}, 
-                {"_2l_blind_elel" , Baseline_blind[2] and NGoodElectrons == 2},
-                {"_2l_blind_mumu" , Baseline_blind[2] and NGoodMuons     == 2},
-                {"_2l_blind_elmu" , Baseline_blind[2] and NGoodElectrons == 1 and NGoodMuons == 1},
-                {"_0l_QCDCR"      , Baseline_CR[0]}, 
-                {"_1l_QCDCR"      , Baseline_CR[1]}, 
-                {"_2l_QCDCR"      , Baseline_CR[1]}, 
+                {"_0l"                , Baseline[0]},
+                {"_1l"                , Baseline[1]},
+                {"_1l_el"             , Baseline[1] and NGoodElectrons == 1},
+                {"_1l_mu"             , Baseline[1] and NGoodMuons     == 1},
+                {"_2l"                , Baseline[2]},
+                {"_2l_elel"           , Baseline[2] and NGoodElectrons == 2},
+                {"_2l_mumu"           , Baseline[2] and NGoodMuons     == 2},
+                {"_2l_elmu"           , Baseline[2] and NGoodElectrons == 1 and NGoodMuons == 1},
+                {"_0l_blind"          , Baseline_blind[0]},
+                {"_1l_blind"          , Baseline_blind[1]},                         
+                {"_1l_blind_el"       , Baseline_blind[1] and NGoodElectrons == 1},
+                {"_1l_blind_mu"       , Baseline_blind[1] and NGoodMuons     == 1},
+                {"_2l_blind"          , Baseline_blind[2]}, 
+                {"_2l_blind_elel"     , Baseline_blind[2] and NGoodElectrons == 2},
+                {"_2l_blind_mumu"     , Baseline_blind[2] and NGoodMuons     == 2},
+                {"_2l_blind_elmu"     , Baseline_blind[2] and NGoodElectrons == 1 and NGoodMuons == 1},
+                {"_0l_QCDCR"          , Baseline_CR[0]}, 
+                {"_1l_QCDCR"          , Baseline_CR[1]}, 
+                {"_2l_QCDCR"          , Baseline_CR[1]}, 
             };
 
             // Put assume 7 jets and 2 leptons for making the histograms
@@ -1340,7 +1353,7 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
                     channel = std::stoi(chunk);
 
                     // One control region for the moment, so pick any of three channels
-                    if (kv.first.find("QCDCR") != std::string::npos)
+                    if (kv.first.find("QCD") != std::string::npos)
                     {
                         isQCD = true;
                     }
@@ -1386,8 +1399,13 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
                     bool        inNjetsBin = njetsPass.second;
                     std::string njetsStr = "";
                     if (njets != "Incl")
+                    {
                         njetsStr = "_Njets" + njets;
-
+                        
+                        if (kv.first.find("blind") != std::string::npos)
+                            continue;
+                    }
+                        
                     // --------------------------------------------------------------------------
                     // loop over the tt and systvars fsrUp/Down, isrUp/Down
                     // to make indivudual histograms with the label tt and systvars in TT root file
@@ -1554,6 +1572,7 @@ void AnalyzeDoubleDisCo::Loop(NTupleReader& tr, double, int maxevents, bool isQu
                                     my_histos["h_JMT_ev2_top6" + name]->Fill(!isQCD ? jmt_ev2_top6[channel] : jmt_ev2_top6_CR[channel], w);
                                     my_histos["h_Mbl"          + name]->Fill(!isQCD ?          Mbl[channel] : Mbl_CR[channel],          w);
                                     my_histos["h_Mll"          + name]->Fill(!isQCD ?          Mll[channel] : Mll_CR[channel],          w);
+                                    my_histos["h_Mbb"          + name]->Fill(!isQCD ?          Mbb[channel] : Mbb_CR[channel],          w);
                                     my_histos["h_dRbjets"      + name]->Fill(!isQCD ?      dRbjets[channel] : dRbjets_CR[channel],      w);
                                     my_histos["h_HT"           + name]->Fill(!isQCD ?      HT_pt30[channel] : HT_pt30_CR[channel],      w);
 

--- a/Analyzer/src/MakeQCDValTree.cc
+++ b/Analyzer/src/MakeQCDValTree.cc
@@ -1,0 +1,144 @@
+#define MakeQCDValTree_cxx
+#include "Analyzer/Analyzer/include/MakeQCDValTree.h"
+#include "NTupleReader/include/NTupleReader.h"
+#include "Framework/Framework/include/MiniTupleMaker.h"
+
+#include <iostream>
+
+MakeQCDValTree::MakeQCDValTree()
+{
+    InitHistos();
+
+    treeInit = false;
+}
+
+void MakeQCDValTree::InitHistos()
+{
+    eventCounter = std::make_shared<TH1D>("EventCounter", "EventCounter", 2, -1.1, 1.1);
+}
+
+void MakeQCDValTree::Loop(NTupleReader& tr, double, int maxevents, bool)
+{
+    while( tr.getNextEvent() )
+    {
+        //------------------------------------
+        //-- Print Event Number
+        //------------------------------------
+        if( maxevents != -1 && tr.getEvtNum() > maxevents )
+            break;
+        if( tr.getEvtNum() % 1000 == 0 )
+            printf( " Event %i\n", tr.getEvtNum() );
+
+        const auto& evtCounter = tr.getVar<int>("eventCounter");
+        eventCounter->Fill(evtCounter);
+
+        const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent");
+        const auto& fastMode       = tr.getVar<bool>("fastMode");
+
+        //if (lostCauseEvent and fastMode){
+        //    continue;
+        //}
+
+        const auto& runtype         = tr.getVar<std::string>("runtype");
+        const auto& filetag         = tr.getVar<std::string>("filetag");
+
+        // General requirements to always pass
+        const auto& JetID               = tr.getVar<bool>("JetID");
+        const auto& passMadHT           = tr.getVar<bool>("passMadHT");
+        const auto& passMETFilters      = tr.getVar<bool>("passMETFilters");
+        const auto& passNonIsoTrigger   = tr.getVar<bool>("passNonIsoTrigger");
+        const auto& passNonIsoTriggerMC = tr.getVar<bool>("passNonIsoTriggerMC");
+        const auto& passElectronHEMveto = tr.getVar<bool>("passElectronHEMveto");
+
+        bool passGeneral = JetID               && 
+                           passMadHT           &&  
+                           passMETFilters      &&  
+                           passNonIsoTrigger   &&  
+                           passNonIsoTriggerMC &&
+                           passElectronHEMveto &&
+                           (runtype != "Data" || filetag.find("Data_SingleMuon") != std::string::npos);
+
+
+        // Relevant lepton quantities
+        const auto& NGoodMuons             = tr.getVar<int>("NGoodMuons");
+        const auto& NGoodElectrons         = tr.getVar<int>("NGoodElectrons");
+        const auto& NNonIsoMuons           = tr.getVar<int>("NNonIsoMuons");
+
+        bool passLeptonReqs = NNonIsoMuons == 1 &&
+                              NGoodMuons == 0   &&
+                              NGoodElectrons == 0;
+
+        const auto& NGoodJets_pt30       = tr.getVar<int>("NGoodJets_pt30");
+
+        if( !treeInit ) {
+            //-----------------------------------
+            //  Initialize the tree
+            //-----------------------------------       
+            std::set<std::string> variables = {
+                "NGoodJets_pt30",
+                "NGoodBJets_pt30",
+                "NNonIsoMuonJets_pt30",
+                "NGoodJets_pt45",
+                "NGoodBJets_pt45",
+                "HT_trigger_pt30",
+                "HT_NonIsoMuon_pt30",
+                "Mbb",
+                "dR_bjets",
+                "nimMbb",
+                "dR_nimbjets",
+                "DoubleDisCo_disc1_NonIsoMuon_0l_RPV",
+                "DoubleDisCo_disc2_NonIsoMuon_0l_RPV",
+                "DoubleDisCo_disc1_NonIsoMuon_0l_SYY",
+                "DoubleDisCo_disc2_NonIsoMuon_0l_SYY",
+                "DoubleDisCo_disc1_NonIsoMuon_1l_RPV",
+                "DoubleDisCo_disc2_NonIsoMuon_1l_RPV",
+                "DoubleDisCo_disc1_NonIsoMuon_1l_SYY",
+                "DoubleDisCo_disc2_NonIsoMuon_1l_SYY",
+                "DoubleDisCo_disc1_0l_RPV",
+                "DoubleDisCo_disc2_0l_RPV",
+                "DoubleDisCo_disc1_0l_SYY",
+                "DoubleDisCo_disc2_0l_SYY",
+                "DoubleDisCo_disc1_1l_RPV",
+                "DoubleDisCo_disc2_1l_RPV",
+                "DoubleDisCo_disc1_1l_SYY",
+                "DoubleDisCo_disc2_1l_SYY",
+            };
+
+            if ( runtype == "MC" )
+            {
+                variables.insert("TotalWeight_QCDCR");
+            }   
+            else
+            {
+                variables.insert("Weight");
+            }
+
+            std::string myTreeName = "PreSelection";
+            myTree = new TTree( (myTreeName).c_str() , (myTreeName).c_str() );
+            myQCDValTuple = new MiniTupleMaker( myTree );
+            myQCDValTuple->setTupleVars(variables);
+            myQCDValTuple->initBranches(tr);
+
+            treeInit = true;
+        }
+        
+        //-----------------------------------
+        //-- Fill Histograms Below
+        //-----------------------------------
+        // Requirements not on NonIsoMuon jets or HT as those will be more restrictive with a non iso muon present
+        if( passGeneral and passLeptonReqs and NGoodJets_pt30 >= 7 ) {
+            myQCDValTuple->fill(tr);
+        }
+    } 
+}
+      
+void MakeQCDValTree::WriteHistos( TFile* outfile ) 
+{
+    outfile->cd();
+    myTree->Write();
+    eventCounter->Write();
+
+    delete myTree;    
+    delete myQCDValTuple;
+
+}

--- a/Analyzer/test/Makefile.in
+++ b/Analyzer/test/Makefile.in
@@ -62,7 +62,7 @@ INCLUDESDIRS += -I$(TDIR) -I$(IFWDIR) -I$(SFWDIR) -I$(IADIR) -I$(SADIR) -I$(INDI
 PROGRAMS = $(ODIR)/rootdict.cc Stack_plot_0l MyAnalysis
 
 ANALYZERS  = $(ODIR)/MiniTupleMaker.o $(ODIR)/CalculateBTagSF.o $(ODIR)/CalculateTopTagSF.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/MakeMiniTree.o $(ODIR)/AnalyzeLepTrigger.o $(ODIR)/AnalyzeTest.o 
-ANALYZERS += $(ODIR)/MakeMiniTree.o $(ODIR)/AnalyzeXsec.o $(ODIR)/MakeNNVariables.o $(ODIR)/AnalyzeDoubleDisCo.o $(ODIR)/AnalyzeGenStop.o
+ANALYZERS += $(ODIR)/MakeQCDValTree.o $(ODIR)/AnalyzeXsec.o $(ODIR)/MakeNNVariables.o $(ODIR)/AnalyzeDoubleDisCo.o $(ODIR)/AnalyzeGenStop.o
 ANALYZERS += $(ODIR)/Semra_Analyzer.o $(ODIR)/ResolvedTopTagger_Analyzer.o $(ODIR)/HEM_Analyzer.o $(ODIR)/TopTaggerSF_Analyzer.o $(ODIR)/ISRJets_Analyzer.o $(ODIR)/HadTriggers_Analyzer.o 
 
 HELPERS  = $(ODIR)/NTupleReader.o $(ODIR)/Utility.o $(ODIR)/samples.o $(ODIR)/EventShapeVariables.o $(ODIR)/SetUpTopTagger.o $(ODIR)/NTRException.o 

--- a/Analyzer/test/MyAnalysis.C
+++ b/Analyzer/test/MyAnalysis.C
@@ -11,6 +11,7 @@
 #include "Analyzer/Analyzer/include/AnalyzeLepTrigger.h"
 #include "Analyzer/Analyzer/include/MakeNJetDists.h"
 #include "Analyzer/Analyzer/include/MakeMiniTree.h"
+#include "Analyzer/Analyzer/include/MakeQCDValTree.h"
 #include "Analyzer/Analyzer/include/CalculateBTagSF.h"
 #include "Analyzer/Analyzer/include/CalculateTopTagSF.h"
 #include "Analyzer/Analyzer/include/CalculateSFMean.h"
@@ -180,6 +181,7 @@ int main(int argc, char *argv[])
         {"CalculateTopTagSF",          run<CalculateTopTagSF>         },
         {"CalculateSFMean",            run<CalculateSFMean>           },
         {"MakeMiniTree",               run<MakeMiniTree>              },
+        {"MakeQCDValTree",             run<MakeQCDValTree>            },
         {"MakeNJetDists",              run<MakeNJetDists>             },
         {"Semra_Analyzer",             run<Semra_Analyzer>            },
         {"ResolvedTopTagger_Analyzer", run<ResolvedTopTagger_Analyzer>},

--- a/Analyzer/test/Plotters/General/miniTupleDrawer.py
+++ b/Analyzer/test/Plotters/General/miniTupleDrawer.py
@@ -1,0 +1,96 @@
+#! /bin/env/python
+
+import os
+import ROOT
+import argparse
+import multiprocessing as mp
+
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat("")
+ROOT.gStyle.SetPaintTextFormat("3.2f")
+ROOT.gStyle.SetFrameLineWidth(2)
+ROOT.gStyle.SetEndErrorSize(0)
+ROOT.TH1.SetDefaultSumw2()
+ROOT.TH2.SetDefaultSumw2()
+
+def makeNDhisto(year, proc, histName, infile, outfile, treeName, histOps):
+
+    selection = histOps["selection"]
+    if "Data" in proc:
+        selection = selection.replace("${WEIGHT}", "Weight")
+    else:
+        selection = selection.replace("${WEIGHT}", "TotalWeight_QCDCR")
+
+    infile.cd()
+    tree = infile.Get(treeName)
+
+    is2D = False
+    if ":" in histOps["variable"]:
+        is2D = True
+
+    outfile.cd()
+
+    htemp = None
+    if not is2D:
+        temph = ROOT.TH1F(histName, "", histOps["xbins"], histOps["xmin"], histOps["xmax"])
+    elif h == None:
+        temph = ROOT.TH2F(histName, "", histOps["xbins"], histOps["xmin"], histOps["xmax"], histOps["ybins"], histOps["ymin"], histOps["ymax"])
+
+    tree.Draw("%s>>%s"%(histOps["variable"], histName), selection)
+       
+    temph = ROOT.gDirectory.Get(histName)
+    temph.Sumw2()
+
+    temph.Write(histName, ROOT.TObject.kOverwrite)
+
+def processFile(outputDir, inputDir, year, proc, histograms, treeName):
+    outfile = ROOT.TFile.Open("%s/%s_%s.root"%(outputDir, year, proc), "UPDATE")
+    infile  = ROOT.TFile.Open("%s/%s_%s.root"%(inputDir, year, proc), "READ")
+    for histName, histOps in histograms.items():
+        if ("SYY" in proc and "SYY" not in histName) or \
+           ("RPV" in proc and "RPV" not in histName):
+               continue 
+        makeNDhisto(year, proc, histName, infile, outfile, treeName, histOps)
+
+    outfile.Close()
+
+usage = "usage: %prog [options]"
+parser = argparse.ArgumentParser(usage)
+parser.add_argument("--path",     dest="path",     help="Path to ntuples",   default="NULL",        required=True)
+parser.add_argument("--tag",      dest="tag",      help="Tag for output",    default="MyTag",                    )
+parser.add_argument("--tree",     dest="tree",     help="TTree name to use", default="PreSelection"              )
+parser.add_argument("--year",     dest="year",     help="which year",                               required=True)
+parser.add_argument("--options",  dest="options",  help="options file",      default="miniTupleDrawer_aux", type=str)
+args = parser.parse_args()
+
+# The auxiliary file contains many "hardcoded" items
+# describing which histograms to get and how to draw
+# them. These things are changed often by the user
+# and thus are kept in separate sidecar file.
+importedGoods = __import__(args.options)
+
+# Names of histograms, rebinning
+histograms = importedGoods.histograms
+
+# Background/signal/data categories to draw
+processes  = importedGoods.processes
+
+tag      = args.tag
+treeName = args.tree
+year     = args.year
+inputDir = args.path
+
+base = os.getenv("CMSSW_BASE")
+
+outputDir = "%s/src/Analyzer/Analyzer/test/%s/"%(base,tag)
+if not os.path.exists(outputDir):
+    os.makedirs(outputDir)
+
+manager = mp.Manager()
+pool = mp.Pool(processes=len(processes))
+
+for proc in processes:
+    pool.apply_async(processFile, args=(outputDir, inputDir, year, proc, histograms, treeName))
+
+pool.close()
+pool.join()

--- a/Analyzer/test/Plotters/General/miniTupleDrawer_aux.py
+++ b/Analyzer/test/Plotters/General/miniTupleDrawer_aux.py
@@ -1,0 +1,73 @@
+#! /bin/env/python
+import copy
+
+regions = {"0l_RPV_A"        : "DoubleDisCo_disc2_0l_RPV>0.6&&DoubleDisCo_disc1_0l_RPV>0.6",
+           "0l_StealthSYY_A" : "DoubleDisCo_disc2_0l_SYY>0.6&&DoubleDisCo_disc1_0l_SYY>0.6",
+           "1l_RPV_A"        : "DoubleDisCo_disc2_1l_RPV>0.6&&DoubleDisCo_disc1_1l_RPV>0.6",
+           "1l_StealthSYY_A" : "DoubleDisCo_disc2_1l_SYY>0.6&&DoubleDisCo_disc1_1l_SYY>0.6",
+
+           "0l_RPV_B"        : "DoubleDisCo_disc2_0l_RPV>0.6&&DoubleDisCo_disc1_0l_RPV<0.6",
+           "0l_StealthSYY_B" : "DoubleDisCo_disc2_0l_SYY>0.6&&DoubleDisCo_disc1_0l_SYY<0.6",
+           "1l_RPV_B"        : "DoubleDisCo_disc2_1l_RPV>0.6&&DoubleDisCo_disc1_1l_RPV<0.6",
+           "1l_StealthSYY_B" : "DoubleDisCo_disc2_1l_SYY>0.6&&DoubleDisCo_disc1_1l_SYY<0.6",
+
+           "0l_RPV_C"        : "DoubleDisCo_disc2_0l_RPV<0.6&&DoubleDisCo_disc1_0l_RPV>0.6",
+           "0l_StealthSYY_C" : "DoubleDisCo_disc2_0l_SYY<0.6&&DoubleDisCo_disc1_0l_SYY>0.6",
+           "1l_RPV_C"        : "DoubleDisCo_disc2_1l_RPV<0.6&&DoubleDisCo_disc1_1l_RPV>0.6",
+           "1l_StealthSYY_C" : "DoubleDisCo_disc2_1l_SYY<0.6&&DoubleDisCo_disc1_1l_SYY>0.6",
+
+           "0l_RPV_D"        : "DoubleDisCo_disc2_0l_RPV<0.6&&DoubleDisCo_disc1_0l_RPV<0.6",
+           "0l_StealthSYY_D" : "DoubleDisCo_disc2_0l_SYY<0.6&&DoubleDisCo_disc1_0l_SYY<0.6",
+           "1l_RPV_D"        : "DoubleDisCo_disc2_1l_RPV<0.6&&DoubleDisCo_disc1_1l_RPV<0.6",
+           "1l_StealthSYY_D" : "DoubleDisCo_disc2_1l_SYY<0.6&&DoubleDisCo_disc1_1l_SYY<0.6",
+}
+
+nbjets = {"Nbjets2incl" : "NGoodBJets_pt30>=2",
+}
+
+njets = {"Njets7"      : "NGoodJets_pt30==7",
+         "Njets7incl"  : "NGoodJets_pt30>=7",
+         "Njets8"      : "NGoodJets_pt30==8",
+         "Njets8incl"  : "NGoodJets_pt30>=8",
+         "Njets9"      : "NGoodJets_pt30==9",
+         "Njets9incl"  : "NGoodJets_pt30>=9",
+         "Njets10"     : "NGoodJets_pt30==10",
+         "Njets10incl" : "NGoodJets_pt30>=10",
+         "Njets11"     : "NGoodJets_pt30==11",
+         "Njets11incl" : "NGoodJets_pt30>=11",
+         "Njets12"     : "NGoodJets_pt30==12",
+         "Njets12incl" : "NGoodJets_pt30>=12",
+         "Njets13"     : "NGoodJets_pt30==13",
+         "Njets13incl" : "NGoodJets_pt30>=13",
+}
+
+histos = {"h_DoubleDisCo_RPV_disc1_disc2_0l" : {"selection" : "${SELECTION}", "variable" : "DoubleDisCo_disc2_0l_RPV:DoubleDisCo_disc1_0l_RPV", "xbins" : 100, "xmin" : 0, "xmax" : 1, "ybins" : 100, "ymin" : 0, "ymax" : 1  }, 
+          "h_DoubleDisCo_SYY_disc1_disc2_0l" : {"selection" : "${SELECTION}", "variable" : "DoubleDisCo_disc2_0l_SYY:DoubleDisCo_disc1_0l_SYY", "xbins" : 100, "xmin" : 0, "xmax" : 1, "ybins" : 100, "ymin" : 0, "ymax" : 1  }, 
+          "h_DoubleDisCo_RPV_disc1_disc2_1l" : {"selection" : "${SELECTION}", "variable" : "DoubleDisCo_disc2_1l_RPV:DoubleDisCo_disc1_1l_RPV", "xbins" : 100, "xmin" : 0, "xmax" : 1, "ybins" : 100, "ymin" : 0, "ymax" : 1  },
+          "h_DoubleDisCo_SYY_disc1_disc2_1l" : {"selection" : "${SELECTION}", "variable" : "DoubleDisCo_disc2_1l_SYY:DoubleDisCo_disc1_1l_SYY", "xbins" : 100, "xmin" : 0, "xmax" : 1, "ybins" : 100, "ymin" : 0, "ymax" : 1  },
+          "h_Mbb"                            : {"selection" : "${SELECTION}", "variable" : "Mbb",                                               "xbins" : 100, "xmin" : 0, "xmax" : 500                                       }, 
+          "h_dRbjets"                        : {"selection" : "${SELECTION}", "variable" : "dR_bjets",                                          "xbins" : 50,  "xmin" : 0, "xmax" : 5                                         },
+          "h_dRbjets_Mbb"                    : {"selection" : "${SELECTION}", "variable" : "Mbb:dR_bjets",                                      "xbins" : 100, "xmin" : 0, "xmax" : 5, "ybins" : 100, "ymin" : 0, "ymax" : 500}, 
+}
+
+histograms = {}
+
+for njetStr, njetExp in njets.items():
+    for nbjetStr, nbjetExp in nbjets.items():
+        for regionStr, regionExp in regions.items():
+            cutStr = "&&".join([njetExp, nbjetExp, regionExp])
+            for histoName, histoOps in histos.items():
+                hopsCopy = copy.copy(histoOps)
+                hopsCopy["selection"] = "${WEIGHT}*(%s)"%("".join(cutStr))
+                histograms["%s_%s_%s_%s"%(histoName,regionStr,njetStr,nbjetStr)] = hopsCopy
+
+processes = [
+    "TT",
+    "QCD",
+    "Non_QCD",
+    "Data_SingleMuon"
+]
+
+for mass in [550]:
+    processes.append("RPV_2t6j_mStop-%d"%(mass))
+    processes.append("StealthSYY_2t6j_mStop-%d"%(mass))


### PR DESCRIPTION
- Add `MakeQCDValTree` analyzer for producing mini tuples with variables of interest.
- Add `miniTupleDrawer.py` and accompanying (also as example) file for doing `TTree.Draw()` on the mini tuples with custom selections, etc. This is generic script that could work with any `TTree`.
- Add a couple of histos to `AnalyzeDoubleDisCo` and remove trivial histo case that reduces total number of histos at no loss.